### PR TITLE
modules: extend Module trait with lifecycle methods and update Manager to call them (#2)

### DIFF
--- a/src/modules/api.rs
+++ b/src/modules/api.rs
@@ -10,4 +10,19 @@ pub trait Module {
         command: &str,
         data: &[u8],
     ) -> Result<Vec<u8>, String>;
+
+    /// Вызывается при загрузке модуля (жизненный цикл)
+    fn on_load(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// Вызывается при выгрузке модуля (жизненный цикл)
+    fn on_unload(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// Вызывается при перезагрузке модуля (жизненный цикл)
+    fn on_reload(&mut self) -> Result<(), String> {
+        Ok(())
+    }
 }

--- a/src/modules/plugin_manager.rs
+++ b/src/modules/plugin_manager.rs
@@ -100,6 +100,31 @@ impl Manager {
             let _ = plugin.handle(cmd, data);
         }
     }
+
+    pub fn load_module(
+        &mut self,
+        module: &mut dyn Module,
+    ) -> Result<(), String> {
+        module.on_load()?;
+        module.init()?;
+        Ok(())
+    }
+
+    pub fn unload_module(
+        &mut self,
+        module: &mut dyn Module,
+    ) -> Result<(), String> {
+        module.on_unload()?;
+        Ok(())
+    }
+
+    pub fn reload_module(
+        &mut self,
+        module: &mut dyn Module,
+    ) -> Result<(), String> {
+        module.on_reload()?;
+        Ok(())
+    }
 }
 
 impl Default for Manager {


### PR DESCRIPTION
### Scope
Modules, plugin manager

### Summary
Добавлен базовый скелет расширения трейта Module и обновлён менеджер для вызова новых методов.

### Status
Это первый этап работы по задаче #2. Логика методов ещё не реализована в модулях, тесты не добавлены.

### Next steps
Продолжу реализацию конкретной логики методов и добавление тестов в этой же ветке.

### Checklist
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [ ] New tests added / existing tests updated
