### PR TITLE
modules: implement CommandRegistry and DbContext with tests; extend M…

### DIFF
--- a/src/command_registry.rs
+++ b/src/command_registry.rs
@@ -1,0 +1,120 @@
+use std::collections::HashMap;
+
+use crate::db_context::DbContext;
+
+/// Ф-я обработчик команды: получает &mut DbContext и сырые аргументы.
+pub type Handler = Box<dyn Fn(&mut DbContext, &[u8]) -> Vec<u8> + Send + Sync>;
+
+pub struct CommandRegistry {
+    handlers: HashMap<String, Handler>,
+}
+
+impl CommandRegistry {
+    pub fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+        }
+    }
+
+    /// Региструет команду `name` с обработчиком `h`.
+    pub fn register<F>(
+        &mut self,
+        name: impl Into<String>,
+        h: F,
+    ) where
+        F: Fn(&mut DbContext, &[u8]) -> Vec<u8> + Send + Sync + 'static,
+    {
+        self.handlers.insert(name.into(), Box::new(h));
+    }
+
+    /// Вызывает handler для `name`. Паникует, если команда не найдена.
+    pub fn call(
+        &self,
+        name: &str,
+        ctx: &mut DbContext,
+        data: &[u8],
+    ) -> Vec<u8> {
+        let h = self
+            .handlers
+            .get(name)
+            .unwrap_or_else(|| panic!("Unknown command: {name}"));
+        h(ctx, data)
+    }
+}
+
+impl Default for CommandRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Sds, Value};
+
+    use super::*;
+
+    #[test]
+    fn test_register_and_call_simple_command() {
+        let mut registry = CommandRegistry::new();
+        let mut ctx = DbContext::new_inmemory();
+
+        registry.register("ping", |_ctx, _data| b"pong".to_vec());
+
+        let result = registry.call("ping", &mut ctx, b"");
+        assert_eq!(result, b"pong");
+    }
+
+    #[test]
+    fn test_command_receives_data() {
+        let mut registry = CommandRegistry::new();
+        let mut ctx = DbContext::new_inmemory();
+
+        registry.register("echo", |_ctx, data| {
+            let mut out = b"echo: ".to_vec();
+            out.extend_from_slice(data);
+            out
+        });
+
+        let result = registry.call("echo", &mut ctx, b"hello");
+        assert_eq!(result, b"echo: hello");
+    }
+
+    #[test]
+    fn test_command_can_use_db_context() {
+        let mut registry = CommandRegistry::new();
+        let mut ctx = DbContext::new_inmemory();
+
+        registry.register("store", |ctx, data| {
+            let key = Sds::from(b"mykey".as_ref());
+            let value = Value::from_bytes(data).unwrap();
+            ctx.set(key, value).unwrap();
+            b"OK".to_vec()
+        });
+
+        registry.register("load", |ctx, _| {
+            let key = Sds::from(b"mykey".as_ref());
+            if let Ok(Some(v)) = ctx.get(key) {
+                v.to_bytes()
+            } else {
+                b"NOT_FOUND".to_vec()
+            }
+        });
+
+        let serialized = Value::Str(Sds::from(b"abc123".as_ref())).to_bytes();
+        registry.call("store", &mut ctx, &serialized);
+
+        let result = registry.call("load", &mut ctx, b"");
+
+        let value = Value::from_bytes(&result).unwrap();
+        assert_eq!(value, Value::Str(Sds::from(b"abc123".as_ref())));
+    }
+
+    #[test]
+    #[should_panic(expected = "Unknown command: missing")]
+    fn test_call_unknown_command_panics() {
+        let registry = CommandRegistry::new();
+        let mut ctx = DbContext::new_inmemory();
+        registry.call("missing", &mut ctx, b"");
+    }
+}

--- a/src/db_context.rs
+++ b/src/db_context.rs
@@ -1,0 +1,65 @@
+use crate::{InMemoryStore, Sds, StorageEngine, StoreResult, Value};
+
+pub struct DbContext {
+    engine: StorageEngine,
+}
+
+impl DbContext {
+    /// Создаёт новый контекст на основе движка памяти.
+    pub fn new_inmemory() -> Self {
+        Self {
+            engine: StorageEngine::Memory(InMemoryStore::new()),
+        }
+    }
+    /// Делегирует `SET key value`.
+    pub fn set(
+        &mut self,
+        key: Sds,
+        value: Value,
+    ) -> StoreResult<()> {
+        self.engine.set(&key, value)
+    }
+    /// Делегируем `GET key`.
+    pub fn get(
+        &self,
+        key: Sds,
+    ) -> StoreResult<Option<Value>> {
+        self.engine.get(&key)
+    }
+    /// Делегируем `DEL key`.
+    pub fn del(
+        &mut self,
+        key: Sds,
+    ) -> StoreResult<bool> {
+        self.engine.del(&key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Value;
+
+    #[test]
+    fn test_set_get_del() {
+        let mut ctx = DbContext::new_inmemory();
+
+        let key = Sds::from(b"foo" as &[u8]);
+        let val = Value::Str(Sds::from(b"bar" as &[u8]));
+
+        let set_result = ctx.set(key.clone(), val.clone());
+        assert!(set_result.is_ok());
+
+        let get_result = ctx.get(key.clone());
+        assert!(get_result.is_ok());
+        assert_eq!(get_result.unwrap(), Some(val.clone()));
+
+        let del_result = ctx.del(key.clone());
+        assert!(del_result.is_ok());
+        assert_eq!(del_result.unwrap(), true);
+
+        let get_after_del = ctx.get(key.clone());
+        assert!(get_after_del.is_ok());
+        assert_eq!(get_after_del.unwrap(), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,12 @@
 pub mod auth;
 /// Разбор и выполнение команд: SET, GET, INCR и др.
 pub mod command;
+pub mod command_registry;
 /// Загрузка конфигурации сервера.
 pub mod config;
 /// Встроенные структуры данных (Dict, SkipList, QuickList, SDS).
 pub mod database;
+pub mod db_context;
 /// Абстракции и реализации движков хранения (InMemory, Persistent, Cluster).
 pub mod engine;
 /// Типы ошибок: кодирование/декодирование, парсинг, хранение.

--- a/src/modules/api.rs
+++ b/src/modules/api.rs
@@ -1,28 +1,45 @@
+use crate::{command_registry::CommandRegistry, db_context::DbContext};
+
 /// Определяем общий интерфейс для всех модулей
 pub trait Module {
     /// Уникальное имя модуля
     fn name(&self) -> &str;
     /// Инициализация (вызывается один раз при загрузке)
-    fn init(&mut self) -> Result<(), String>;
+    fn init(
+        &mut self,
+        registry: &mut CommandRegistry,
+        ctx: &mut DbContext,
+    ) -> Result<(), String>;
     /// Обработка входящего сообщения или команды
     fn handle(
         &mut self,
         command: &str,
         data: &[u8],
+        ctx: &mut DbContext,
     ) -> Result<Vec<u8>, String>;
 
-    /// Вызывается при загрузке модуля (жизненный цикл)
-    fn on_load(&mut self) -> Result<(), String> {
+    /// Жизненный цикл: вызывается при загрузке модуля
+    fn on_load(
+        &mut self,
+        _registry: &mut CommandRegistry,
+        _ctx: &mut DbContext,
+    ) -> Result<(), String> {
         Ok(())
     }
 
-    /// Вызывается при выгрузке модуля (жизненный цикл)
-    fn on_unload(&mut self) -> Result<(), String> {
+    /// Жизненный цикл: вызывается при выгрузке модуля
+    fn on_unload(
+        &mut self,
+        _ctx: &mut DbContext,
+    ) -> Result<(), String> {
         Ok(())
     }
 
-    /// Вызывается при перезагрузке модуля (жизненный цикл)
-    fn on_reload(&mut self) -> Result<(), String> {
+    /// Жизненный цикл: вызывается при перезагрузке модуля
+    fn on_reload(
+        &mut self,
+        _ctx: &mut DbContext,
+    ) -> Result<(), String> {
         Ok(())
     }
 }

--- a/src/modules/plugin_manager.rs
+++ b/src/modules/plugin_manager.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use wasmtime::Engine;
 
-use crate::{DynamicModule, Module, WasmPlugin};
+use crate::{
+    command_registry::CommandRegistry, db_context::DbContext, DynamicModule, Module, WasmPlugin,
+};
 
 /// Тип плагина: либо встроенный Rust, либо динамический .so/.dll, либо WASM
 pub enum Plugin {
@@ -17,23 +19,62 @@ pub struct Manager {
 }
 
 impl Plugin {
-    pub fn init(&mut self) -> Result<(), String> {
+    pub fn init(
+        &mut self,
+        registry: &mut CommandRegistry,
+        ctx: &mut DbContext,
+    ) -> Result<(), String> {
         match self {
-            Plugin::Native(m) => m.init(),
-            Plugin::Dynamic(d) => d.module_mut().init(),
-            Plugin::Wasm(w) => w.init(),
+            Plugin::Native(m) => m.init(registry, ctx),
+            Plugin::Dynamic(d) => d.module_mut().init(registry, ctx),
+            Plugin::Wasm(w) => w.init(registry, ctx),
         }
     }
 
     pub fn handle(
         &mut self,
-        cmd: &str,
+        command: &str,
         data: &[u8],
+        ctx: &mut DbContext,
     ) -> Result<Vec<u8>, String> {
         match self {
-            Plugin::Native(m) => m.handle(cmd, data),
-            Plugin::Dynamic(d) => d.module_mut().handle(cmd, data),
-            Plugin::Wasm(w) => w.handle(cmd, data),
+            Plugin::Native(m) => m.handle(command, data, ctx),
+            Plugin::Dynamic(d) => d.module_mut().handle(command, data, ctx),
+            Plugin::Wasm(w) => w.handle(command, data, ctx),
+        }
+    }
+
+    pub fn on_load(
+        &mut self,
+        registry: &mut CommandRegistry,
+        ctx: &mut DbContext,
+    ) -> Result<(), String> {
+        match self {
+            Plugin::Native(m) => m.on_load(registry, ctx),
+            Plugin::Dynamic(d) => d.module_mut().on_load(registry, ctx),
+            Plugin::Wasm(w) => w.on_load(registry, ctx),
+        }
+    }
+
+    pub fn on_unload(
+        &mut self,
+        ctx: &mut DbContext,
+    ) -> Result<(), String> {
+        match self {
+            Plugin::Native(m) => m.on_unload(ctx),
+            Plugin::Dynamic(d) => d.module_mut().on_unload(ctx),
+            Plugin::Wasm(w) => w.on_unload(ctx),
+        }
+    }
+
+    pub fn on_reload(
+        &mut self,
+        ctx: &mut DbContext,
+    ) -> Result<(), String> {
+        match self {
+            Plugin::Native(m) => m.on_reload(ctx),
+            Plugin::Dynamic(d) => d.module_mut().on_reload(ctx),
+            Plugin::Wasm(w) => w.on_reload(ctx),
         }
     }
 }
@@ -49,9 +90,9 @@ impl Manager {
     /// Добавляет встроенный (статический скомпилированный) модуль.
     pub fn add_native(
         &mut self,
-        m: Box<dyn Module>,
+        module: Box<dyn Module>,
     ) {
-        self.plugins.push(Plugin::Native(m));
+        self.plugins.push(Plugin::Native(module));
     }
 
     /// Добавляет динамический плагин из .so/.dll.
@@ -82,47 +123,38 @@ impl Manager {
         Ok(())
     }
 
-    /// Инициализация всех загруженных модулей.
-    pub fn init_all(&mut self) -> Result<(), String> {
+    /// Инициализирует все плагины (`on_load` + `init`)
+    pub fn init_all(
+        &mut self,
+        registry: &mut CommandRegistry,
+        ctx: &mut DbContext,
+    ) -> Result<(), String> {
         for plugin in &mut self.plugins {
-            plugin.init()?;
+            plugin.on_load(registry, ctx)?;
+            plugin.init(registry, ctx)?;
         }
         Ok(())
     }
 
-    /// Передаёт комнду всем плагинам.
-    pub fn broadcast(
+    /// Выгружает все плагины (`on_unload`)
+    pub fn unload_all(
         &mut self,
-        cmd: &str,
-        data: &[u8],
-    ) {
+        ctx: &mut DbContext,
+    ) -> Result<(), String> {
         for plugin in &mut self.plugins {
-            let _ = plugin.handle(cmd, data);
+            plugin.on_unload(ctx)?;
         }
-    }
-
-    pub fn load_module(
-        &mut self,
-        module: &mut dyn Module,
-    ) -> Result<(), String> {
-        module.on_load()?;
-        module.init()?;
         Ok(())
     }
 
-    pub fn unload_module(
+    /// Перезагружает все плагины (`on_reload`)
+    pub fn reload_all(
         &mut self,
-        module: &mut dyn Module,
+        ctx: &mut DbContext,
     ) -> Result<(), String> {
-        module.on_unload()?;
-        Ok(())
-    }
-
-    pub fn reload_module(
-        &mut self,
-        module: &mut dyn Module,
-    ) -> Result<(), String> {
-        module.on_reload()?;
+        for plugin in &mut self.plugins {
+            plugin.on_reload(ctx)?;
+        }
         Ok(())
     }
 }
@@ -130,5 +162,113 @@ impl Manager {
 impl Default for Manager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{command_registry::CommandRegistry, db_context::DbContext, Module};
+    use std::sync::{Arc, Mutex};
+
+    // Заглушка для Module для тестов
+    struct DummyModule {
+        init_called: Arc<Mutex<bool>>,
+        handle_called: Arc<Mutex<bool>>,
+    }
+
+    impl DummyModule {
+        fn new() -> Self {
+            Self {
+                init_called: Arc::new(Mutex::new(false)),
+                handle_called: Arc::new(Mutex::new(false)),
+            }
+        }
+    }
+
+    impl Module for DummyModule {
+        fn name(&self) -> &str {
+            "dummy"
+        }
+        fn init(
+            &mut self,
+            _registry: &mut CommandRegistry,
+            _ctx: &mut DbContext,
+        ) -> Result<(), String> {
+            *self.init_called.lock().unwrap() = true;
+            Ok(())
+        }
+        fn handle(
+            &mut self,
+            _command: &str,
+            _data: &[u8],
+            _ctx: &mut DbContext,
+        ) -> Result<Vec<u8>, String> {
+            *self.handle_called.lock().unwrap() = true;
+            Ok(b"ok".to_vec())
+        }
+        fn on_load(
+            &mut self,
+            _registry: &mut CommandRegistry,
+            _ctx: &mut DbContext,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+        fn on_unload(
+            &mut self,
+            _ctx: &mut DbContext,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+        fn on_reload(
+            &mut self,
+            _ctx: &mut DbContext,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_manager_add_and_init_native() {
+        let mut manager = Manager::new();
+        let mut registry = CommandRegistry::new(); // Предполагается, что есть метод new
+        let mut ctx = DbContext::new_inmemory();
+
+        let dummy = Box::new(DummyModule::new());
+        manager.add_native(dummy);
+
+        assert!(manager.init_all(&mut registry, &mut ctx).is_ok());
+
+        // Можно проверить, что init был вызван, если у DummyModule флаги
+        // Но для этого нужно вернуть объект DummyModule наружу или хранить Arc флаги в тесте
+    }
+
+    #[test]
+    fn test_manager_handle_native() {
+        let mut manager = Manager::new();
+        let mut registry = CommandRegistry::new();
+        let mut ctx = DbContext::new_inmemory();
+
+        let dummy = Box::new(DummyModule::new());
+        manager.add_native(dummy);
+
+        manager.init_all(&mut registry, &mut ctx).unwrap();
+
+        // Обращаемся к первому плагину (у нас только один)
+        let res = manager.plugins[0].handle("test_cmd", b"data", &mut ctx);
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap(), b"ok".to_vec());
+    }
+
+    #[test]
+    fn test_manager_unload_and_reload() {
+        let mut manager = Manager::new();
+        let mut ctx = DbContext::new_inmemory();
+
+        let dummy = Box::new(DummyModule::new());
+        manager.add_native(dummy);
+
+        assert!(manager.unload_all(&mut ctx).is_ok());
+        assert!(manager.reload_all(&mut ctx).is_ok());
     }
 }


### PR DESCRIPTION
# Pull Request: Extend Module Trait and Plugin Manager (#2)

## Scope
Modules, plugin manager, database, command registration.

## Summary
- Implemented `CommandRegistry` for registering and calling commands.
- Added `DbContext` — context for database operations.
- Extended the `Module` trait with new methods accepting `CommandRegistry` and `DbContext`.
- Updated the plugin manager (`Manager`) to support the new methods and integrate command registration and database context.
- Added tests for new components and methods.

## Testing
- Unit tests for `CommandRegistry` and `DbContext`.
- Tests for the plugin manager with dummy modules.
- Manual testing of plugin loading and initialization.

## Checklist
- [x] Passed `cargo fmt --check`
- [x] Passed `cargo clippy -- -D warnings`
- [x] Added new tests / updated existing tests

---

> Note: This is an intermediate step for issue #2.  
> Some method logic and additional tests will be added in future commits.  
> The PR is left open for further development and discussion.
