### PR TITLE
Fix Clippy warning: replace assert_eq! with assert! (#2)

### DIFF
--- a/src/db_context.rs
+++ b/src/db_context.rs
@@ -56,7 +56,7 @@ mod tests {
 
         let del_result = ctx.del(key.clone());
         assert!(del_result.is_ok());
-        assert_eq!(del_result.unwrap(), true);
+        assert!(del_result.unwrap());
 
         let get_after_del = ctx.get(key.clone());
         assert!(get_after_del.is_ok());


### PR DESCRIPTION
# Fix Clippy warning: replace `assert_eq!` with `assert!` in DbContext tests

## Scope
Testing, code quality, lint fixes.

## Summary
- Fixed Clippy warning related to using `assert_eq!` for boolean checks.
- Replaced `assert_eq!(del_result.unwrap(), true)` with more idiomatic `assert!(del_result.unwrap())`.
- This fix allows the CI checks to pass without errors.

## Testing
- Ran all existing unit tests.
- Verified successful CI runs (Clippy, formatting, tests).

## Checklist
- [x] Passed `cargo fmt --check`
- [x] Passed `cargo clippy -- -D warnings`
- [x] No new tests needed, existing tests updated

---

> Note: This is an intermediate fix to continue work on issue #2.  
> The PR remains open for further changes and improvements.
