### PR TITLE
fix: use modern format syntax `{err}` instead of `"{}", err` to satisfy clippy (#12)

### DIFF
--- a/src/engine/zdb/file.rs
+++ b/src/engine/zdb/file.rs
@@ -402,7 +402,7 @@ mod tests {
             found: 99,
             supported: vec![FormatVersion::V1, FormatVersion::V2],
         };
-        let msg = format!("{}", err);
+        let msg = format!("{err}");
         assert!(msg.contains("Unsupported ZDB dump version: 99"));
         assert!(msg.contains("V1"));
         assert!(msg.contains("V2"));


### PR DESCRIPTION
## Scope
zdb, error handling, formatting

## Summary
This commit fixes a Clippy lint warning by replacing `format!("{}", err)` calls with the more idiomatic `format!("{err}")` syntax.

## Testing
- Ran `cargo fmt --check` to ensure formatting compliance.
- Ran `cargo clippy -- -D warnings` to verify no Clippy warnings remain.
- Ran all unit tests (`cargo test`) successfully.

## Checklist
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] New tests added / existing tests updated (no new tests needed as this is a formatting fix)

---

Closes #12
