### PR TITLE
fix(ci): address clippy uninlined_format_args lint warnings

### DIFF
--- a/src/pubsub/broker.rs
+++ b/src/pubsub/broker.rs
@@ -682,7 +682,7 @@ mod tests {
 
         // Публикуем много сообщений, чтобы переполнить буфер
         for i in 0..10 {
-            broker.publish("lag_channel", Bytes::from(format!("msg{}", i)));
+            broker.publish("lag_channel", Bytes::from(format!("msg{i}")));
         }
 
         // Первое получение может вернуть Lagged ошибку
@@ -690,9 +690,9 @@ mod tests {
             Ok(_) => {} // Иногда получаем сообщение
             Err(BroadcastRecvError::Lagged(n)) => {
                 assert!(n > 0);
-                println!("Successfully caught lagged error: {} messages", n);
+                println!("Successfully caught lagged error: {n} messages");
             }
-            Err(e) => panic!("Unexpected error: {}", e),
+            Err(e) => panic!("Unexpected error: {e}"),
         }
     }
 }

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -34,7 +34,7 @@ async fn test_real_world_usage_example() -> Result<(), Box<dyn std::error::Error
                 }
                 Err(RecvError::Closed) => break,
                 Err(RecvError::Lagged(n)) => {
-                    messages.push(format!("Missed {} notifications", n));
+                    messages.push(format!("Missed {n} notifications"));
                 }
             }
         }


### PR DESCRIPTION
### Description

This pull request addresses the `clippy::uninlined_format_args` lint warnings that caused the CI/CD pipeline to fail after the recent merge (related to #17).

The previous changes introduced an ergonomic asynchronous API for pub/sub subscriptions (originally implemented in #17). However, the CI/CD system, with its strict linting rules, failed due to the use of older `format!` and `println!` syntax.

### Key Changes

-   **Linting Fixes:** Updated all instances of `format!`, `println!`, and `panic!` macros to use the modern Rust syntax with captured identifiers (e.g., `format!("msg{i}")` instead of `format!("msg{}", i)`). This resolves the `uninlined_format_args` Clippy warnings.
-   Ensures the codebase now fully complies with current Rust formatting best practices and passes all CI/CD checks.

Comprehensive tests for the async API are already in place and were not modified in this fix.

---

**Refs #17**
