### PR TITLE
feat(pubsub): implement robust error handling with dedicated RecvError enum (#20)

### DIFF
--- a/benches/broker_benchmarks.rs
+++ b/benches/broker_benchmarks.rs
@@ -30,7 +30,9 @@ fn bench_publish_0_sub(c: &mut Criterion) {
     let broker = Broker::new(100);
     c.bench_function("publish_0_subs", |b| {
         b.iter(|| {
-            broker.publish("chan", black_box(Bytes::from_static(b"x")));
+            broker
+                .publish("chan", black_box(Bytes::from_static(b"x")))
+                .unwrap();
         })
     });
 }
@@ -40,27 +42,35 @@ fn bench_publish_1_sub(c: &mut Criterion) {
     let _sub = broker.subscribe("chan");
     c.bench_function("publish_1_sub", |b| {
         b.iter(|| {
-            broker.publish("chan", black_box(Bytes::from_static(b"x")));
+            broker
+                .publish("chan", black_box(Bytes::from_static(b"x")))
+                .unwrap();
         })
     });
 }
 
 fn bench_publish_10_sub(c: &mut Criterion) {
     let broker = Broker::new(100);
-    let _subs: Vec<Subscription> = (0..10).map(|_| broker.subscribe("chan")).collect();
+    let _subs: Vec<Subscription> = (0..10).map(|_| broker.subscribe("chan").unwrap()).collect();
     c.bench_function("publish_10_subs", |b| {
         b.iter(|| {
-            broker.publish("chan", black_box(Bytes::from_static(b"x")));
+            broker
+                .publish("chan", black_box(Bytes::from_static(b"x")))
+                .unwrap();
         })
     });
 }
 
 fn bench_publish_100_sub(c: &mut Criterion) {
     let broker = Broker::new(100);
-    let _subs: Vec<Subscription> = (0..100).map(|_| broker.subscribe("chan")).collect();
+    let _subs: Vec<Subscription> = (0..100)
+        .map(|_| broker.subscribe("chan").unwrap())
+        .collect();
     c.bench_function("publish_100_subs", |b| {
         b.iter(|| {
-            broker.publish("chan", black_box(Bytes::from_static(b"x")));
+            broker
+                .publish("chan", black_box(Bytes::from_static(b"x")))
+                .unwrap();
         })
     });
 }

--- a/benches/subscription_benchmarks.rs
+++ b/benches/subscription_benchmarks.rs
@@ -19,7 +19,7 @@ fn bench_unsubscribe(c: &mut Criterion) {
     let broker = Broker::new(100);
     c.bench_function("unsubscribe", |b| {
         b.iter(|| {
-            let sub = broker.subscribe("chan");
+            let sub = broker.subscribe("chan").unwrap();
             sub.unsubscribe();
             black_box(());
         });
@@ -31,7 +31,9 @@ fn bench_publish_1_sub(c: &mut Criterion) {
     let _sub = broker.subscribe("chan");
     c.bench_function("publish_1_sub", |b| {
         b.iter(|| {
-            broker.publish("chan", black_box(Bytes::from_static(b"x")));
+            broker
+                .publish("chan", black_box(Bytes::from_static(b"x")))
+                .unwrap();
         })
     });
 }
@@ -39,10 +41,12 @@ fn bench_publish_1_sub(c: &mut Criterion) {
 fn bench_publish_10_sub(c: &mut Criterion) {
     let broker = Broker::new(100);
     // создаём 10 подписок заранее
-    let _subs: Vec<Subscription> = (0..10).map(|_| broker.subscribe("chan")).collect();
+    let _subs: Vec<Subscription> = (0..10).map(|_| broker.subscribe("chan").unwrap()).collect();
     c.bench_function("publish_10_sub", |b| {
         b.iter(|| {
-            broker.publish("chan", black_box(Bytes::from_static(b"x")));
+            broker
+                .publish("chan", black_box(Bytes::from_static(b"x")))
+                .unwrap();
         })
     });
 }
@@ -50,10 +54,14 @@ fn bench_publish_10_sub(c: &mut Criterion) {
 fn bench_publish_100_sub(c: &mut Criterion) {
     let broker = Broker::new(100);
     // создаём 100 подписок заранее
-    let _subs: Vec<Subscription> = (0..100).map(|_| broker.subscribe("chan")).collect();
+    let _subs: Vec<Subscription> = (0..100)
+        .map(|_| broker.subscribe("chan").unwrap())
+        .collect();
     c.bench_function("publish_100_sub", |b| {
         b.iter(|| {
-            broker.publish("chan", black_box(Bytes::from_static(b"x")));
+            broker
+                .publish("chan", black_box(Bytes::from_static(b"x")))
+                .unwrap();
         })
     });
 }


### PR DESCRIPTION
This pull request implements robust and centralized error handling for the PubSub subsystem by introducing the dedicated `RecvError` and `TryRecvError` enums.

Key improvements:
- Defined comprehensive `RecvError` and `TryRecvError` enums representing various error scenarios such as channel closure, timeout, serialization errors, lagged receivers, invalid patterns, subscriber limit exceeded, and channel not found.
- Centralized error definitions in the module `src/error/pubsub.rs` for better modularity and maintainability.
- Updated PubSub APIs to use these error enums for more precise and descriptive error handling.
- Implemented conversions from Tokio broadcast and Globset errors to these new error types.
- Maintained backward compatibility and ensured smooth integration with the global error handling system.

This enhancement improves code clarity, debugging, and type safety in the PubSub implementation.

---

**Closes #20**
