### PR TITLE
Setup zumic-cli binary module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 target/
 dist
 tmp
-/bin
 **/cargo-target
 
 # Вывод mdBook (генератор документации)
@@ -44,6 +43,5 @@ test_zdb_roundtrip.**
 
 # Разное
 debug/
-bin
 client
 results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,10 +54,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -343,21 +387,36 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -383,6 +442,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.12",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "config"
@@ -1162,6 +1227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1614,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -2378,6 +2455,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -3746,6 +3829,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "clap",
  "config",
  "crc16",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,14 @@ arbitrary = { version = "1.3", features = ["derive"] }
 unsafe_code = "forbid"
 unused = { level = "warn", priority = -1 }
 
+[[bin]]
+name = "zumic"
+path = "src/main.rs"
+
+[[bin]]
+name = "zumic-cli"
+path = "src/bin/zumic-cli.rs"
+
 [dependencies]
 anyhow = "1.0"
 argon2 = "0.5.3"
@@ -81,6 +89,7 @@ zstd = "0.13.3"
 uuid = { version = "1", features = ["serde", "v4"] }
 lazy_static = "1.4"
 parking_lot = "0.12.5"
+clap = { version = "4.5", features = ["derive", "env", "cargo"] }
 
 [dependencies.wasmtime]
 version = "34.0.1"
@@ -116,7 +125,7 @@ harness = false
 [workspace]
 members = [
     ".",    # главный пакет (zumic)
-    "fuzz", # fuzz crate
+    "fuzz"  # fuzz crate
 ]
 
 [workspace.package]

--- a/src/bin/zumic-cli.rs
+++ b/src/bin/zumic-cli.rs
@@ -1,0 +1,436 @@
+//! CLI клиент Zumic
+//!
+//! Клиент командной строки для взаимодействия с сервером Zumic.
+//! Поддерживает интерактивный режим (REPL), одиночные команды,
+//! получение информации о сервере, мониторинг и бенчмарки.
+
+use std::{net::SocketAddr, time::Duration};
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use tracing::{debug, info};
+
+/// Основная структура CLI аргументов
+///
+/// Содержит параметры подключения к серверу, таймауты, формат вывода,
+/// а также подкоманду или прямой набор аргументов.
+#[derive(Parser)]
+#[command(name = "zumic-cli")]
+#[command(author = "Zumic Contributors")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(about = "CLI клиент для Zumic сервера", long_about = None)]
+#[command(propagate_version = true)]
+struct Cli {
+    /// Хост сервера (IP или доменное имя)
+    #[arg(
+        short = 'H',
+        long,
+        default_value = "127.0.0.1",
+        env = "ZUMIC_HOST",
+        help = "Хост сервера для подключения"
+    )]
+    host: String,
+    /// Порт сервера
+    #[arg(
+        short,
+        long,
+        default_value = "6174",
+        env = "ZUMIC_PORT",
+        help = "Порт сервера для подключения"
+    )]
+    port: u16,
+    /// Пароль для аутентификации
+    #[arg(
+        short,
+        long,
+        env = "ZUMIC_PASSWORD",
+        help = "Пароль для аутентификации (можно использовать переменную окружения ZUMIC_PASSWORD)"
+    )]
+    auth: Option<String>,
+    /// Таймаут соединения в секундах
+    #[arg(long, default_value = "5", help = "Таймаут соединения в секундах")]
+    timeout: u64,
+    /// Таймаут чтения данных в секундах
+    #[arg(
+        long,
+        default_value = "30",
+        help = "Таймаут ожидания ответа сервера в секундах"
+    )]
+    read_timeout: u64,
+    /// Таймаут записи данных в секундах
+    #[arg(
+        long,
+        default_value = "10",
+        help = "Таймаут отправки команды серверу в секундах"
+    )]
+    write_timeout: u64,
+    /// Включить подробный вывод (debug)
+    #[arg(short, long, help = "Включить подробный вывод для отладки")]
+    verbose: bool,
+    /// Формат вывода результатов
+    #[arg(
+        long,
+        value_enum,
+        default_value = "pretty",
+        help = "Формат вывода ответа сервера"
+    )]
+    output: OutputFormat,
+    /// Подкоманда для выполнения
+    #[command(subcommand)]
+    command: Option<Commands>,
+    /// Прямое выполнение команды (например: GET key)
+    #[arg(help = "Прямая команда для выполнения (например, 'GET key' или 'SET key value')")]
+    args: Vec<String>,
+}
+
+/// Формат вывода CLI
+#[derive(Clone, Debug, clap::ValueEnum)]
+enum OutputFormat {
+    /// Человекочитаемый формат
+    Pretty,
+    /// Сырой протокольный вывод
+    Raw,
+    /// JSON формат
+    Json,
+}
+
+/// Подкоманды CLI
+#[derive(Subcommand)]
+enum Commands {
+    /// Интерактивный режим (REPL)
+    #[command(alias = "i")]
+    Interactive {
+        /// Путь к файлу истории команд
+        #[arg(
+            long,
+            default_value = "~/.zumic_history",
+            help = "Файл для сохранения истории команд"
+        )]
+        history: String,
+    },
+    /// Выполнить одну команду и выйти
+    #[command(alias = "e")]
+    Exec {
+        /// Команда с аргументами
+        #[arg(required = true, help = "Команда для выполнения (например, 'GET key')")]
+        args: Vec<String>,
+    },
+    /// Проверка соединения с сервером
+    Ping {
+        /// Количество пингов
+        #[arg(
+            short = 'c',
+            long,
+            default_value = "1",
+            help = "Количество пингов для отправки"
+        )]
+        count: u32,
+
+        /// Интервал между пингами (мс)
+        #[arg(
+            short,
+            long,
+            default_value = "1000",
+            help = "Интервал между пингами в миллисекундах"
+        )]
+        interval: u64,
+    },
+    /// Получить информацию о сервере
+    #[command(alias = "status")]
+    Info {
+        /// Раздел информации (например: server, memory, stats)
+        #[arg(help = "Название раздела информации (например, 'server', 'memory', 'stats')")]
+        section: Option<String>,
+    },
+    /// Режим мониторинга команд (реaltime)
+    Monitor,
+    /// Запуск бенчмарка
+    #[command(alias = "bench")]
+    Benchmark {
+        /// Количество запросов
+        #[arg(
+            short = 'n',
+            long,
+            default_value = "100000",
+            help = "Количество запросов для теста"
+        )]
+        requests: usize,
+        /// Количество параллельных клиентов
+        #[arg(
+            short = 'c',
+            long,
+            default_value = "50",
+            help = "Количество параллельных клиентов"
+        )]
+        clients: usize,
+        /// Тестируемые команды (например: SET,GET)
+        #[arg(
+            short = 't',
+            long,
+            default_value = "SET,GET",
+            help = "Список команд для тестирования"
+        )]
+        tests: String,
+    },
+}
+
+/// Конфигурация CLI после разбора аргументов
+///
+/// Содержит серверный адрес, таймауты, пароль и формат вывода
+#[derive(Debug, Clone)]
+struct CliConfig {
+    server_addr: SocketAddr,
+    #[allow(dead_code)]
+    auth: Option<String>,
+    #[allow(dead_code)]
+    timeout: Duration,
+    #[allow(dead_code)]
+    read_timeout: Duration,
+    #[allow(dead_code)]
+    write_timeout: Duration,
+    #[allow(dead_code)]
+    verbose: bool,
+    #[allow(dead_code)]
+    output_format: OutputFormat,
+}
+
+impl TryFrom<&Cli> for CliConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(cli: &Cli) -> Result<Self> {
+        let server_addr: SocketAddr = format!("{}:{}", cli.host, cli.port)
+            .parse()
+            .context("Неверный формат адреса сервера")?;
+
+        Ok(Self {
+            server_addr,
+            auth: cli.auth.clone(),
+            timeout: Duration::from_secs(cli.timeout),
+            read_timeout: Duration::from_secs(cli.read_timeout),
+            write_timeout: Duration::from_secs(cli.write_timeout),
+            verbose: cli.verbose,
+            output_format: cli.output.clone(),
+        })
+    }
+}
+
+/// Точка входа в CLI
+///
+/// Разбирает аргументы, инициализирует логирование, печатает баннер
+/// и вызывает обработчик команды.
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    // Инициализация логирования
+    init_logging(cli.verbose)?;
+
+    // Баннер CLI
+    print_banner();
+
+    // Конфигурация CLI
+    let config = CliConfig::try_from(&cli)?;
+
+    debug!("Конфигурация CLI: {config:?}");
+    info!("Подключение к {}...", config.server_addr);
+
+    // Обработка команды
+    match handle_command(&cli, &config).await {
+        Ok(_) => {
+            debug!("Команда выполнена успешно");
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Обработчик выполнения команд
+async fn handle_command(
+    cli: &Cli,
+    config: &CliConfig,
+) -> Result<()> {
+    match &cli.command {
+        // Interactive mode
+        Some(Commands::Interactive { history }) => {
+            info!("Запуск интерактивного режима...");
+            interactive_mode(config, history).await
+        }
+
+        // Execute single command from subcommand
+        Some(Commands::Exec { args }) => {
+            debug!("Выполнение команды: {args:?}");
+            execute_command(config, args).await
+        }
+
+        // Ping command
+        Some(Commands::Ping { count, interval }) => {
+            ping_server(config, *count, Duration::from_millis(*interval)).await
+        }
+
+        // Info command
+        Some(Commands::Info { section }) => get_server_info(config, section.as_deref()).await,
+
+        // Monitor mode
+        Some(Commands::Monitor) => monitor_mode(config).await,
+
+        // Benchmark mode
+        Some(Commands::Benchmark {
+            requests,
+            clients,
+            tests,
+        }) => run_benchmark(config, *requests, *clients, tests).await,
+
+        // No subcommand - check if args provided
+        None => {
+            if cli.args.is_empty() {
+                // Default to interactive mode
+                info!("Команда не указана, запускается интерактивный режим...");
+                interactive_mode(config, "~/.zumic_history").await
+            } else {
+                // Execute direct command
+                debug!("Выполнение прямой команды: {:?}", cli.args);
+                execute_command(config, &cli.args).await
+            }
+        }
+    }
+}
+
+/// Инициализация логирования
+fn init_logging(verbose: bool) -> Result<()> {
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let filter = if verbose {
+        EnvFilter::new("debug")
+    } else {
+        EnvFilter::new("info")
+    };
+
+    fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .with_thread_ids(false)
+        .with_file(false)
+        .with_line_number(false)
+        .try_init()
+        .map_err(|e| anyhow::anyhow!("Ошибка инициализации логирования: {e}"))?;
+
+    Ok(())
+}
+
+/// Баннер CLI
+fn print_banner() {
+    println!("┌─────────────────────────────────────────┐");
+    println!(
+        "│                   Zumic CLI v{}         │",
+        env!("CARGO_PKG_VERSION")
+    );
+    println!("│   Интерфейс командной строки            │");
+    println!("└─────────────────────────────────────────┘");
+    println!();
+}
+
+/// Интерактивный режим (REPL)
+async fn interactive_mode(
+    config: &CliConfig,
+    _history_path: &str,
+) -> Result<()> {
+    println!("🚧 Интерактивный режим - пока заглушка");
+    println!("   Сервер: {}", config.server_addr);
+    println!("   Введите 'help' для списка команд");
+    println!("   Введите 'quit' или 'exit' для выхода");
+    println!();
+    println!("Пока используйте: zumic-cli exec <команда>");
+    Ok(())
+}
+
+/// Выполнение одной команды
+async fn execute_command(
+    config: &CliConfig,
+    args: &[String],
+) -> Result<()> {
+    println!("🚧 Режим выполнения команды - пока заглушка");
+    println!("   Сервер: {}", config.server_addr);
+    println!("   Команда: {}", args.join(" "));
+    println!();
+    println!("Следующие шаги:");
+    println!("   1. Реализовать подключение к ZSP клиенту");
+    println!("   2. Добавить выполнение команд");
+    Ok(())
+}
+
+/// Ping сервера
+async fn ping_server(
+    config: &CliConfig,
+    count: u32,
+    interval: Duration,
+) -> Result<()> {
+    println!("🚧 Режим Ping - пока заглушка");
+    println!("   Сервер: {}", config.server_addr);
+    println!("   Количество пингов: {count}, Интервал: {interval:?}");
+    println!();
+    println!("Будет отправлен PING и измерена задержка");
+    Ok(())
+}
+
+/// Информация о сервере
+async fn get_server_info(
+    config: &CliConfig,
+    section: Option<&str>,
+) -> Result<()> {
+    println!("🚧 Режим информации - пока заглушка");
+    println!("   Сервер: {}", config.server_addr);
+    if let Some(sec) = section {
+        println!("   Раздел: {sec}");
+    }
+    println!();
+    println!("Будет получена статистика и конфигурация сервера");
+    Ok(())
+}
+
+/// Режим мониторинга команд
+async fn monitor_mode(config: &CliConfig) -> Result<()> {
+    println!("🚧 Режим мониторинга - пока заглушка");
+    println!("   Сервер: {}", config.server_addr);
+    println!();
+    println!("Будет отображаться поток команд в реальном времени");
+    Ok(())
+}
+
+/// Запуск бенчмарка
+async fn run_benchmark(
+    config: &CliConfig,
+    requests: usize,
+    clients: usize,
+    tests: &str,
+) -> Result<()> {
+    println!("🚧 Режим бенчмарка - пока заглушка");
+    println!("   Сервер: {}", config.server_addr);
+    println!("   Запросов: {requests}, Клиентов: {clients}");
+    println!("   Тестируемые команды: {tests}");
+    println!();
+    println!("Будет выполнено тестирование производительности");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_cli_parsing() {
+        let cli = Cli::parse_from(["zumic-cli", "--help"]);
+        // Исправлено: используем is_none() вместо matches!(..., None) чтобы
+        // удовлетворить clippy
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn test_config_from_cli() {
+        let cli = Cli::parse_from(["zumic-cli", "-h", "localhost", "-p", "6174"]);
+        let config = CliConfig::try_from(&cli).unwrap();
+        assert_eq!(config.server_addr.port(), 6174);
+    }
+}


### PR DESCRIPTION
This Pull Request closes #33 by implementing the setup of the zumic-cli binary module within the workspace:

- Added `zumic-cli` binary to `Cargo.toml` workspace.
- Created entry point at `src/bin/zumic-cli.rs`.
- Set up basic CLI argument parsing with `clap`.
- Implemented basic `--help` and `--version` flags.
- Verified `cargo build --bin zumic-cli` compiles successfully.
- Ensured correct output of `zumic-cli --help` and `zumic-cli --version`.

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated

Closes #33