### PR TITLE
feat(zumic-error): added additional tests for network error

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,7 +9,7 @@ target = "x86_64-unknown-linux-gnu"
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 
-# Если планируешь собирать для ARM и использовать
+# Поддержка кросс-компиляции ARM и использовать
 # минималистичный линкер (musl)
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"

--- a/zumic-error/src/types/network.rs
+++ b/zumic-error/src/types/network.rs
@@ -134,6 +134,8 @@ impl ErrorExt for NetworkError {
 mod tests {
     use super::*;
 
+    /// Тест проверяет: ConnectionFailed — код статуса, клиентское сообщение и
+    /// метки.
     #[test]
     fn test_connection_failed() {
         let err = NetworkError::ConnectionFailed {
@@ -148,13 +150,134 @@ mod tests {
             .any(|(k, v)| k == &"address" && v == "127.0.0.1:6379"));
     }
 
+    /// Тест проверяет: ConnectionClosed с причиной и без неё.
+    #[test]
+    fn test_connection_closed() {
+        let err_with_reason = NetworkError::ConnectionClosed {
+            reason: Some("remote reset".into()),
+        };
+        assert_eq!(err_with_reason.status_code(), StatusCode::ConnectionClosed);
+        assert!(err_with_reason.to_string().contains("remote reset"));
+
+        let err_without_reason = NetworkError::ConnectionClosed { reason: None };
+        assert_eq!(err_without_reason.client_message(), "Connection closed");
+        assert!(err_without_reason.to_string().contains("Connection closed"));
+    }
+
+    /// Тест проверяет: ReadTimeout и WriteTimeout — статус и сообщение.
+    #[test]
+    fn test_read_write_timeout() {
+        let read = NetworkError::ReadTimeout;
+        assert_eq!(read.status_code(), StatusCode::ReadTimeout);
+        assert_eq!(read.client_message(), "Read timeout");
+        assert!(read.to_string().contains("Read timeout"));
+
+        let write = NetworkError::WriteTimeout;
+        assert_eq!(write.status_code(), StatusCode::WriteTimeout);
+        assert_eq!(write.client_message(), "Write timeout");
+        assert!(write.to_string().contains("Write timeout"));
+    }
+
+    /// Тест проверяет: UnexpectedResponse — статус, клиентское сообщение и
+    /// вывод Display.
+    #[test]
+    fn test_unexpected_response() {
+        let err = NetworkError::UnexpectedResponse {
+            expected: "PONG".into(),
+            got: "ERR".into(),
+        };
+        assert_eq!(err.status_code(), StatusCode::ProtocolError);
+        assert_eq!(err.client_message(), "Unexpected server response");
+        assert!(err.to_string().contains("expected PONG"));
+    }
+
+    /// Тест проверяет: ProtocolError — статус, сообщение и вывод Display.
+    #[test]
+    fn test_protocol_error() {
+        let err = NetworkError::ProtocolError {
+            reason: "invalid frame".into(),
+        };
+        assert_eq!(err.status_code(), StatusCode::ProtocolError);
+        assert_eq!(err.client_message(), "Protocol error");
+        assert!(err.to_string().contains("Protocol error"));
+    }
+
+    /// Тест проверяет: TooManyConnections — статус, retryable флаг, метки
+    /// current/max и сообщение.
     #[test]
     fn test_too_many_connections() {
         let err = NetworkError::TooManyConnections {
-            current: 1000,
-            max: 1000,
+            current: 100,
+            max: 100,
         };
         assert_eq!(err.status_code(), StatusCode::TooManyConnections);
+        assert_eq!(err.client_message(), "Too many connections");
+        assert!(err.to_string().contains("100/100"));
+        let tags = err.metrics_tags();
+        assert!(tags.iter().any(|(k, _)| *k == "current_connections"));
+        assert!(tags.iter().any(|(k, _)| *k == "max_connections"));
         assert!(err.status_code().is_retryable());
+    }
+
+    /// Тест проверяет: ParseError, EncodingError и DecodingError — коды
+    /// статусов, сообщения и форматирование.
+    #[test]
+    fn test_parse_and_codec_errors() {
+        let parse = NetworkError::ParseError {
+            reason: "bad syntax".into(),
+        };
+        assert_eq!(parse.status_code(), StatusCode::ParseError);
+        assert_eq!(parse.client_message(), "Invalid command format");
+        assert!(parse.to_string().contains("Parse error"));
+
+        let enc = NetworkError::EncodingError {
+            reason: "utf8 invalid".into(),
+        };
+        assert_eq!(enc.status_code(), StatusCode::EncodingError);
+        assert_eq!(enc.client_message(), "Encoding error");
+        assert!(enc.to_string().contains("Encoding error"));
+
+        let dec = NetworkError::DecodingError {
+            reason: "truncated".into(),
+        };
+        assert_eq!(dec.status_code(), StatusCode::DecodingError);
+        assert_eq!(dec.client_message(), "Decoding error");
+        assert!(dec.to_string().contains("Decoding error"));
+    }
+
+    /// Тест проверяет: IncompleteData — статус, сообщение и корректность
+    /// вывода.
+    #[test]
+    fn test_incomplete_data() {
+        let err = NetworkError::IncompleteData {
+            expected: 1024,
+            got: 512,
+        };
+        assert_eq!(err.status_code(), StatusCode::UnexpectedEof);
+        assert_eq!(err.client_message(), "Incomplete data received");
+        assert!(err.to_string().contains("expected 1024"));
+    }
+
+    /// Тест проверяет: as_any даёт возможность безопасного downcast к
+    /// NetworkError.
+    #[test]
+    fn test_as_any_downcast() {
+        let err = NetworkError::WriteTimeout;
+        let any_ref = err.as_any();
+        assert!(any_ref.downcast_ref::<NetworkError>().is_some());
+    }
+
+    /// Тест проверяет: базовые теги metrics_tags для всех вариантов содержат
+    /// error_type и status_code.
+    #[test]
+    fn test_common_metrics_tags() {
+        let err = NetworkError::ProtocolError {
+            reason: "bad header".into(),
+        };
+        let tags = err.metrics_tags();
+        assert!(tags
+            .iter()
+            .any(|(k, v)| k == &"error_type" && v == "network"));
+        assert!(tags.iter().any(|(k, _)| k == &"status_code"));
     }
 }


### PR DESCRIPTION
added additional tests for network error

# Pull Request

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated
