### PR TITLE
feat(decode): strict EOF handling and skip_bytes in StreamingParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ doc**/*
 # Файлы окружения и секреты
 .env
 zumic.conf
-zumic.aof
 
 # Рабочее пространство VSCode
 *.code-workspace
@@ -39,7 +38,8 @@ zumic.aof
 *.wasm
 
 # Артефакты тестов
-test_zdb_roundtrip.**
+*.zdb
+*.aof
 
 # Разное
 debug/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,9 @@ pub use database::{
 };
 /// Реэкспорт движков хранения.
 pub use engine::{
-    load_from_reader, load_from_zdb, save_to_zdb, AofLog, GlobalShardStats, InMemoryStore,
-    InPersistentStore, Shard, ShardId, ShardMetrics, ShardMetricsSnapshot, ShardedIndex,
-    ShardingConfig, SlotId, SlotManager, SlotState, Storage, StorageEngine, SyncPolicy,
+    load_from_zdb, save_to_zdb, AofLog, GlobalShardStats, InMemoryStore, InPersistentStore, Shard,
+    ShardId, ShardMetrics, ShardMetricsSnapshot, ShardedIndex, ShardingConfig, SlotId, SlotManager,
+    SlotState, Storage, StorageEngine, SyncPolicy,
 };
 /// Реэкспорт основных типов ошибок.
 pub use error::{


### PR DESCRIPTION
zdb: strict EOF handling in StreamingParser; strict skip_bytes in decode.rs; add truncated-value test; update CHANGELOG

- StreamingParser: treat UnexpectedEof after parsed records as error (fix truncated dump detection)
- decode: make skip_bytes strict (returns UnexpectedEof when bytes missing)
- Add test test_truncated_value_fails for read_value_with_version 
- Update CHANGELOG (Unreleased) with details

# Pull Request

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated
