### PR TITLE
feat(hll): added additional tests for hll_dense and hll_sparse

### DIFF
--- a/src/database/hll/hll_dense.rs
+++ b/src/database/hll/hll_dense.rs
@@ -22,8 +22,8 @@ impl<const P: usize> HllDense<P> {
     }
 
     /// Возвращает heap-часть, занятую dense-представлением:
-    /// - размер структуры HllDense (Vec metadata) — будет на куче, т.к.
-    ///   HllDense хранится в Box
+    /// - size_of::<HllDense>() — структура, размещённая в куче под Box
+    ///   (включает Vec metadata: ptr, len, cap)
     /// - плюс реальная capacity() в байтах (Vec<u8>)
     /// - плюс небольшой консервативный overhead для аллокатора
     pub fn memory_footprint(&self) -> usize {
@@ -273,5 +273,13 @@ mod tests {
         for &idx in &test_indices {
             assert_eq!(dense.get_register(idx), 42);
         }
+    }
+
+    #[test]
+    fn test_dense_memory_footprint_is_reasonable() {
+        let dense = HllDense::<14>::new();
+        let mem = dense.memory_footprint();
+        let min = std::mem::size_of::<HllDense<14>>() + dense.size();
+        assert!(mem >= min);
     }
 }

--- a/src/database/hll/hll_sparse.rs
+++ b/src/database/hll/hll_sparse.rs
@@ -279,4 +279,31 @@ mod tests {
 
         assert_eq!(sparse, deserialized);
     }
+
+    #[test]
+    fn test_merge_idempotent() {
+        let mut sparse = HllSparse::<14>::new();
+
+        for i in 0..100 {
+            sparse.set_register(i, (i % 63 + 1) as u8);
+        }
+
+        let before = sparse.clone();
+        sparse.merge(&before);
+
+        assert_eq!(sparse, before);
+    }
+
+    #[test]
+    fn test_memory_monotonic_growth() {
+        let mut sparse = HllSparse::<14>::new();
+        let mut last = sparse.memory_footprint();
+
+        for i in 0..200 {
+            sparse.set_register(i, 1);
+            let now = sparse.memory_footprint();
+            assert!(now >= last);
+            last = now;
+        }
+    }
 }


### PR DESCRIPTION
Added additional tests for `hll_dense` and `hll_sparse`:

* `test_dense_memory_footprint_is_reasonable` — verifies memory footprint invariant
* `test_merge_idempotent` — ensures merge is idempotent
* `test_memory_monotonic_growth` — checks monotonic memory footprint growth

Also clarified the documentation comment for `HllDense::memory_footprint`.

# Pull Request

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated
  - [x] Added the necessary rustdoc comments.
  - [x] Changelog updated if applicable
