### PR TITLE
feat(hll): introduce XxHasher hasher abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,6 +1746,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "murmur3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4401,6 +4407,7 @@ dependencies = [
  "lru",
  "memchr",
  "mlua",
+ "murmur3",
  "num-integer",
  "num_cpus",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ tracing-subscriber = { version = "0.3", features = [
 uuid = { version = "1", features = ["serde", "v4"] }
 zstd = "0.13.3"
 zumic-error = { workspace = true }
+murmur3 = "0.5.2"
 
 [dependencies.wasmtime]
 version = "36.0.3"

--- a/src/database/hll/hll_hash.rs
+++ b/src/database/hll/hll_hash.rs
@@ -1,16 +1,19 @@
 pub trait HllHasher: Default + Clone {
-    /// Хеширует срез байт в 64-битное значение.
     fn hash_bytes(
         &self,
         bytes: &[u8],
     ) -> u64;
 
-    /// Возвращает имя хешера.
     fn name(&self) -> &'static str;
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct MurmurHasher {
+    seed: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct XxHasher {
     seed: u64,
 }
 
@@ -24,13 +27,25 @@ impl MurmurHasher {
     }
 }
 
+impl XxHasher {
+    pub fn new(seed: u64) -> Self {
+        Self { seed }
+    }
+
+    pub fn with_default_seed() -> Self {
+        Self::new(0)
+    }
+}
+
 impl Default for MurmurHasher {
-    /// Возвращает «значение по умолчанию» для типа. Значения по умолчанию часто
-    /// представляют собой какое-либо начальное значение, значение идентичности
-    /// или что-либо еще, что может иметь смысл в качестве значения по
-    /// умолчанию.
     fn default() -> Self {
         Self::new(0)
+    }
+}
+
+impl Default for XxHasher {
+    fn default() -> Self {
+        Self::with_default_seed()
     }
 }
 
@@ -47,8 +62,22 @@ impl HllHasher for MurmurHasher {
     }
 }
 
-/// MurmurHash3 64 битная реализация.
-/// ВАЖНО: это упрощённая реализация и в дальнеёшем будет переход на `murmur3`.
+impl HllHasher for XxHasher {
+    fn hash_bytes(
+        &self,
+        bytes: &[u8],
+    ) -> u64 {
+        xxhash64(bytes, self.seed)
+    }
+
+    fn name(&self) -> &'static str {
+        "xxHash64"
+    }
+}
+
+/// MurmurHash3 64-bit implementation.
+/// NOTE: This is a simplified implementation and will be upgraded to `murmur3`
+/// in the future.
 fn murmur3_64(
     data: &[u8],
     seed: u64,
@@ -62,7 +91,7 @@ fn murmur3_64(
     let mut h = seed;
     let len = data.len();
 
-    // Обработка 8-байтовых блоков
+    // Processing 8-byte chunks
     let chunks = data.chunks_exact(8);
     let remainder = chunks.remainder();
 
@@ -78,7 +107,7 @@ fn murmur3_64(
         h = h.wrapping_mul(M).wrapping_add(0x52dce729);
     }
 
-    // Обработка оставшихся байтов
+    // Processing the remaining bytes
     if !remainder.is_empty() {
         let mut k: u64 = 0;
         for (i, &byte) in remainder.iter().enumerate() {
@@ -91,7 +120,7 @@ fn murmur3_64(
         h ^= k;
     }
 
-    // Завершение
+    // Finalization
     h ^= len as u64;
     h ^= h >> 33;
     h = h.wrapping_mul(0xff51afd7ed558ccd);
@@ -100,6 +129,92 @@ fn murmur3_64(
     h ^= h >> 33;
 
     h
+}
+
+/// xxhash64 implementation.
+/// NOTE: This is a simplified implementation and will be upgraded to
+/// `xxhash-rust` in the future.
+fn xxhash64(
+    data: &[u8],
+    seed: u64,
+) -> u64 {
+    const PRIME1: u64 = 0x9e3779b185ebca87;
+    const PRIME2: u64 = 0xc2b2ae3d27d4eb4f;
+    const PRIME3: u64 = 0x165667b19e3779f9;
+    const _PRIME4: u64 = 0x85ebca77c2b2ae63;
+    const PRIME5: u64 = 0x27d4eb2f165667c5;
+
+    let mut h64: u64;
+    let len = data.len();
+
+    if len >= 32 {
+        let mut v1 = seed.wrapping_add(PRIME1).wrapping_add(PRIME2);
+        let mut v2 = seed.wrapping_add(PRIME2);
+        let mut v3 = seed;
+        let mut v4 = seed.wrapping_sub(PRIME1);
+
+        let chunks = data.chunks_exact(32);
+        for chunk in chunks {
+            v1 = round(v1, u64::from_le_bytes(chunk[0..8].try_into().unwrap()));
+            v2 = round(v2, u64::from_le_bytes(chunk[8..16].try_into().unwrap()));
+            v3 = round(v3, u64::from_le_bytes(chunk[16..24].try_into().unwrap()));
+            v4 = round(v4, u64::from_le_bytes(chunk[24..32].try_into().unwrap()));
+        }
+
+        h64 = v1
+            .rotate_left(1)
+            .wrapping_add(v2.rotate_left(7))
+            .wrapping_add(v3.rotate_left(12))
+            .wrapping_add(v4.rotate_left(18));
+
+        h64 = merge_round(h64, v1);
+        h64 = merge_round(h64, v2);
+        h64 = merge_round(h64, v3);
+        h64 = merge_round(h64, v4);
+    } else {
+        h64 = seed.wrapping_add(PRIME5);
+    }
+
+    h64 = h64.wrapping_add(len as u64);
+
+    // Process remaining data (simplified)
+    let remaining = &data[data.len() - (data.len() % 32)..];
+    for &byte in remaining {
+        h64 ^= (byte as u64).wrapping_mul(PRIME5);
+        h64 = h64.rotate_left(11).wrapping_mul(PRIME1);
+    }
+
+    // Finalization
+    h64 ^= h64 >> 33;
+    h64 = h64.wrapping_mul(PRIME2);
+    h64 ^= h64 >> 29;
+    h64 = h64.wrapping_mul(PRIME3);
+    h64 ^= h64 >> 32;
+
+    h64
+}
+
+fn round(
+    acc: u64,
+    input: u64,
+) -> u64 {
+    const PRIME1: u64 = 0x9e3779b185ebca87;
+    const PRIME2: u64 = 0xc2b2ae3d27d4eb4f;
+
+    acc.wrapping_add(input.wrapping_mul(PRIME2))
+        .rotate_left(31)
+        .wrapping_mul(PRIME1)
+}
+
+fn merge_round(
+    acc: u64,
+    val: u64,
+) -> u64 {
+    const PRIME1: u64 = 0x9e3779b185ebca87;
+    const PRIME2: u64 = 0xc2b2ae3d27d4eb4f;
+
+    let val = round(0, val);
+    acc ^ val.wrapping_mul(PRIME1).wrapping_add(PRIME2)
 }
 
 #[cfg(test)]
@@ -117,6 +232,19 @@ mod tests {
         assert_eq!(hash1, hash2);
         assert_ne!(hash1, hash3);
         assert_eq!(hasher.name(), "MurmurHash3");
+    }
+
+    #[test]
+    fn test_xxhash() {
+        let hasher = XxHasher::default();
+
+        let hash1 = hasher.hash_bytes(b"foo");
+        let hash2 = hasher.hash_bytes(b"foo");
+        let hash3 = hasher.hash_bytes(b"bar");
+
+        assert_eq!(hash1, hash2);
+        assert_ne!(hash1, hash3);
+        assert_eq!(hasher.name(), "xxHash64");
     }
 
     #[test]
@@ -144,11 +272,11 @@ mod tests {
             hashes.push(hash);
         }
 
-        // Проверяем, что хеши хорошо распределены
+        // Check that the hashes are well distributed
         hashes.sort_unstable();
         hashes.dedup();
 
-        // Должно быть почти 10000 уникальных хешей
+        // The should be almost 10_000 unique hashes
         assert!(
             hashes.len() > 9990,
             "Too many collisions: {}",


### PR DESCRIPTION
- temporary in-house XxHasher impl (will switch to `xxhash-rust` crate later)
- adds unit tests for determinism, seed, distribution

# Pull Request

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated
  - [x] Added the necessary rustdoc comments.
  - [x] Changelog updated if applicable
