### PR TITLE
feat(benches): added focused benchmarks for HLL hashers

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [[bench]]
 name = "zumic-benchmark"
-path = "benches/hll_benchmark/hll.rs"
+path = "benches/hll_benchmark/hll_hash.rs"
 harness = false
 
 [lints]

--- a/benches/benches/hll_benchmark/hll_hash.rs
+++ b/benches/benches/hll_benchmark/hll_hash.rs
@@ -1,0 +1,106 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use zumic::database::{HllHasher, MurmurHasher, SipHasher, XxHasher};
+
+/// Генерирует тестовую полезную нагрузку заданного размера с детерминированными
+/// псевдослучайными данными.
+fn make_payload(
+    size: usize,
+    seed: u64,
+) -> Vec<u8> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..size).map(|_| rng.gen::<u8>()).collect()
+}
+
+/// Микробенчмарк: вызов хеш-функции для одной полезной нагрузки
+fn bench_single_hash<H: HllHasher + 'static + Send + Sync>(
+    c: &mut Criterion,
+    name: &str,
+    payload_size: usize,
+) {
+    let payload = make_payload(payload_size, 0xfeedu64);
+
+    let mut group = c.benchmark_group(format!("hash/single/{}b", payload_size));
+    group.throughput(criterion::Throughput::Bytes(payload_size as u64));
+    group.bench_function(BenchmarkId::new(name, ""), |b| {
+        let hasher = H::default();
+        b.iter(|| {
+            // black_box чтобы избежать оптимизации
+            black_box(hasher.hash_bytes(black_box(&payload)));
+        })
+    });
+    group.finish();
+}
+
+/// Тестирование производительности в пакетном режиме: множество хешей в плотном
+/// цикле (моделирует «горячий путь»)
+fn bench_batch_hash<H: HllHasher + 'static + Send + Sync>(
+    c: &mut Criterion,
+    name: &str,
+    payload_size: usize,
+    batch: usize,
+) {
+    // Подготовка пакетную обработку различных полезных нагрузок, чтобы избежать
+    // случайных попаданий в кэш.
+    let payloads: Vec<Vec<u8>> = (0..batch)
+        .map(|i| make_payload(payload_size, 0xDEAD_0000u64 + i as u64))
+        .collect();
+
+    let mut group = c.benchmark_group(format!("hash/batch/{}b_x{}", payload_size, batch));
+    group.bench_function(BenchmarkId::new(name, ""), |b| {
+        let hasher = H::default();
+        b.iter(|| {
+            for p in &payloads {
+                black_box(hasher.hash_bytes(black_box(p)));
+            }
+        })
+    });
+    group.finish();
+}
+
+pub fn hashers_comparison(c: &mut Criterion) {
+    // Размеры выбраны с учетом типичной рабочей нагрузки HLL:
+    // малый — 16 байт (идентификатор, короткая клавиша)
+    // средний — 64 байта
+    // большой — 1024 байта (стрессовая нагрузка)
+    let sizes = [16usize, 64usize, 1024usize];
+
+    // Микростенд для одного вызова для каждого молотка и каждого размера
+    for &size in &sizes {
+        bench_single_hash::<MurmurHasher>(c, "murmur", size);
+        bench_single_hash::<XxHasher>(c, "xxhash", size);
+        bench_single_hash::<SipHasher>(c, "siphash", size);
+    }
+
+    // Тесты производительности пакетной обработки — моделирование пропускной
+    // способности на «горячем» пути
+    let batch = 1024usize; // количество хешей за итерацию
+    for &size in &[16usize, 64usize] {
+        bench_batch_hash::<MurmurHasher>(c, "murmur", size, batch);
+        bench_batch_hash::<XxHasher>(c, "xxhash", size, batch);
+        bench_batch_hash::<SipHasher>(c, "siphash", size, batch);
+    }
+
+    // Дополнительно: небольшой bench для сравнения трех групп для получения точных
+    // числовых данных.
+    let payload = make_payload(64, 0xBEEF);
+    let mut group = c.benchmark_group("hash/compare/64b");
+    group.bench_function("murmur", |b| {
+        let h = MurmurHasher::default();
+        b.iter(|| black_box(h.hash_bytes(black_box(&payload))));
+    });
+    group.bench_function("xxhash", |b| {
+        let h = XxHasher::default();
+        b.iter(|| black_box(h.hash_bytes(black_box(&payload))));
+    });
+    group.bench_function("siphash", |b| {
+        let h = SipHasher::default();
+        b.iter(|| black_box(h.hash_bytes(black_box(&payload))));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, hashers_comparison);
+criterion_main!(benches);


### PR DESCRIPTION
* added focused benchmarks for HLL hashers:
  * introduced Criterion benchmarks for `hll_hash.rs`
  * covered MurmurHash, xxHash and SipHash
  * measured:
    - single hash latency for 16B / 64B / 1024B payloads
    - batch hashing throughput (1024 hashes per iteration)
    - direct side-by-side comparison for 64B inputs

* benchmark results:
  * xxHash is consistently the fastest hasher:
    - ~5.4 ns (16B), ~11.6 ns (64B), ~72.7 ns (1024B)
    - up to ~13 GiB/s on large payloads
  * SipHash shows balanced performance:
    - ~9.0 ns (16B), ~19.0 ns (64B), ~222 ns (1024B)
    - faster than MurmurHash, significantly slower than xxHash
  * MurmurHash is the slowest across all sizes:
    - ~11.7 ns (16B), ~25.7 ns (64B), ~322 ns (1024B)

* batch benchmarks (1024 hashes per iteration):
  * xxHash: ~4.2 µs (16B), ~11.5 µs (64B)
  * SipHash: ~10.3 µs (16B), ~20.2 µs (64B)
  * MurmurHash: ~12.6 µs (16B), ~27.3 µs (64B)

* conclusions:
  * hashing cost dominates HLL `add()` hot path
  * xxHash is the best default choice for performance-critical workloads
  * SipHash provides a reasonable security/performance trade-off
  * MurmurHash is noticeably slower and less competitive for HLL use


# Pull Request

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated
  - [x] Added the necessary rustdoc comments.
  - [x] Changelog updated if applicable
