### PR TITLE
feat(benches): added metrics for HLL hash benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# zumic
+# Zumic
 
 > ⚠️ Project Status: Active development. Experimental project. Not yet production-ready (except for basic persistent mode).
 


### PR DESCRIPTION
Replaced the default `DefaultHasher` with configurable, high‑performance hashing back‑ends optimized for HyperLogLog (HLL).  
Provides MurmurHash (standard), xxHash (fastest), and SipHash (crypto‑safe) backed implementations, configurable through a common trait interface.  
Adds a full benchmark & metrics suite for deterministic, distributed HLL operation.

# Pull Request

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated
  - [x] Added the necessary rustdoc comments.
  - [x] Changelog updated if applicable

Closes #196