### PR TITLE
feat(command): added benchmarks for smarthash

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [[bench]]
 name = "zumic-benchmark"
-path = "benches/hll_benchmark/hll_sparse.rs"
+path = "benches/smarthash_benchmark/smarthash_bench.rs"
 harness = false
 
 [lints]

--- a/benches/benches/smarthash_benchmark/smarthash_bench.rs
+++ b/benches/benches/smarthash_benchmark/smarthash_bench.rs
@@ -1,0 +1,147 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use zumic::{
+    CommandExecute, HGetCommand, HIncrByCommand, HIncrByFloatCommand, HSetCommand, InMemoryStore,
+    StorageEngine, Value,
+};
+
+// ==============================================================================
+// Вспомогательные функции: создать store с начальным количеством счетчиков.
+// ==============================================================================
+fn init_store_int() -> StorageEngine {
+    let mut store = StorageEngine::Memory(InMemoryStore::new());
+    HSetCommand {
+        key: "counter".into(),
+        entries: vec![("hits".into(), "0".into())],
+    }
+    .execute(&mut store)
+    .unwrap();
+    store
+}
+
+fn init_store_float() -> StorageEngine {
+    let mut store = StorageEngine::Memory(InMemoryStore::new());
+    HSetCommand {
+        key: "float_counter".into(),
+        entries: vec![("hits".into(), "0.0".into())],
+    }
+    .execute(&mut store)
+    .unwrap();
+    store
+}
+
+// ==============================================================================
+// Сравнительный тест: HINCRBY атомарный против ручного режима
+// ==============================================================================
+fn benchmark_hincrby_atomic(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hash_increment_int");
+
+    group.bench_function("hincrby_atomic", |b| {
+        b.iter(|| {
+            let mut store = init_store_int();
+
+            for _ in 0..1000 {
+                HIncrByCommand {
+                    key: "counter".into(),
+                    field: "hits".into(),
+                    increment: black_box(1),
+                }
+                .execute(&mut store)
+                .unwrap();
+            }
+        });
+    });
+
+    group.bench_function("hget_hset_manual", |b| {
+        b.iter(|| {
+            let mut store = init_store_int();
+
+            for _ in 0..1000 {
+                let current = HGetCommand {
+                    key: "counter".into(),
+                    field: "hits".into(),
+                }
+                .execute(&mut store)
+                .unwrap();
+
+                let val: i64 = match current {
+                    Value::Str(s) => s.as_str().unwrap_or("0").parse().unwrap_or(0),
+                    _ => 0,
+                };
+
+                let new_val = val + black_box(1);
+
+                HSetCommand {
+                    key: "counter".into(),
+                    entries: vec![("hits".into(), new_val.to_string())],
+                }
+                .execute(&mut store)
+                .unwrap();
+            }
+        });
+    });
+
+    group.finish();
+}
+
+// ==============================================================================
+// Сравнительный тест: HINCRBYFLOAT атомарный против ручного
+// ==============================================================================
+fn benchmark_hincrbyfloat_atomic(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hash_increment_float");
+
+    group.bench_function("hincrbyfloat_atomic", |b| {
+        b.iter(|| {
+            let mut store = init_store_float();
+
+            for _ in 0..1000 {
+                HIncrByFloatCommand {
+                    key: "float_counter".into(),
+                    field: "hits".into(),
+                    increment: black_box(1.5),
+                }
+                .execute(&mut store)
+                .unwrap();
+            }
+        });
+    });
+
+    group.bench_function("hget_parse_set_manual_float", |b| {
+        b.iter(|| {
+            let mut store = init_store_float();
+
+            for _ in 0..1000 {
+                let current = HGetCommand {
+                    key: "float_counter".into(),
+                    field: "hits".into(),
+                }
+                .execute(&mut store)
+                .unwrap();
+
+                let val: f64 = match current {
+                    Value::Str(s) => s.as_str().unwrap_or("0.0").parse().unwrap_or(0.0),
+                    _ => 0.0,
+                };
+
+                let new_val = val + black_box(1.5);
+
+                HSetCommand {
+                    key: "float_counter".into(),
+                    entries: vec![("hits".into(), new_val.to_string())],
+                }
+                .execute(&mut store)
+                .unwrap();
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchmark_hincrby_atomic,
+    benchmark_hincrbyfloat_atomic
+);
+criterion_main!(benches);


### PR DESCRIPTION
Implemented Redis‑style `HINCRBY` and `HINCRBYFLOAT` for SmartHash with strict numeric validation, overflow protection, and atomic read‑modify‑write semantics.  
The commands now support safe integer and floating‑point counters, reject invalid numeric states (`NaN`/`Infinity`), and are wired into the command layer with proper error mapping.

- `HINCRBY`  
  - Treats missing field as `0`  
  - Parses existing value as `i64`, uses checked arithmetic for overflow/underflow  
  - Fails if value is non‑numeric or exceeds `i64` range  
  - Entire operation is atomic inside SmartHash

- `HINCRBYFLOAT`  
  - Treats missing field as `0.0`  
  - Parses existing value as `f64`, rejects results that become `NaN` or `Infinity`  
  - Preserves Redis‑like semantics but with stricter safety for floats  

**Testing:**  
- Unit tests for both commands:  
  - New field vs existing field, positive/negative increments  
  - Non‑numeric values, wrong key type, integer overflow/underflow  
  - Float edge‑cases: `NaN`, `Infinity` results are rejected  
- Benchmarks (`cargo bench -p zumic-benchmark`):  
  - Integer increments: atomic `HINCRBY` is ~1.7× faster than manual `HGET` + `HSET`  
    - `hincrby_atomic`: ~195 µs  
    - `hget_hset_manual`: ~339 µs  
  - Float increments: atomic `HINCRBYFLOAT` is ~1.5× faster than manual parse/set  
    - `hincrbyfloat_atomic`: ~270 µs  
    - `hget_parse_set_manual_float`: ~406 µs

# Pull Request

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated
  - [x] Added the necessary rustdoc comments.
  - [x] Changelog updated if applicable
Closes #209