### PR TITLE
feat(skiplist): added additional methods for concurrency

### DIFF
--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -185,7 +185,9 @@ zumic
 │   │   │   ├── mod.rs
 │   │   │   └── sds_base.rs
 │   │   ├── skiplist
+│   │   │   ├── concurrent.rs
 │   │   │   ├── mod.rs
+│   │   │   ├── safety.rs
 │   │   │   └── skiplist_base.rs
 │   │   ├── smarthash
 │   │   │   ├── mod.rs


### PR DESCRIPTION
- In `concurrent.rs`, added:
  - the `validate_invariants` method
  - the `with_read` method
  - the `with_write` method
  - additional tests covering the newly introduced methods

# Pull Request

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated
  - [x] Added the necessary rustdoc comments.
  - [x] Changelog updated if applicable