### PR TITLE
feat(skiplist): replace std::sync::RwLock with parking_lot::RwLock fo…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ optional = true
 version = "1.3"
 
 [features]
-default = []
+default = ["concurrent"]
 concurrent = []
 fuzz = []
 avx512 = []
@@ -178,3 +178,11 @@ opt-level = 1     # меньше оптимизаций быстрее сбор�
 lto = false       # отключаем link-time optimization (жрет память)
 codegen-units = 1 # пусть компилятор компилирует последовательно
 debug = 1         # сохраняем минимум отладочной информации
+
+[profile.test]
+opt-level = 1
+
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Конкретный nightly для воспроизводимости. Обновляй по необходимости.
-channel = "nightly-2025-05-10"
+channel = "nightly-2026-02-14"
 components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]

--- a/src/command/hash.rs
+++ b/src/command/hash.rs
@@ -301,7 +301,7 @@ impl CommandExecute for HGetAllCommand {
             Some(Value::Hash(mut sh)) => {
                 // сортируем ключи для предсказуемого порядка
                 let mut entries: Vec<_> = sh.iter().collect();
-                entries.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+                entries.sort_by_key(|(k1, _)| *k1);
 
                 let result: QuickList<Sds> = QuickList::from_iter(
                     entries

--- a/src/database/skiplist/mod.rs
+++ b/src/database/skiplist/mod.rs
@@ -1,11 +1,25 @@
-pub mod concurrent;
+//! SkipList - потокобезопасная реализация для Zumic.
+//!
+//! # Модули
+//!
+//! - `skiplist_base`: базовая однопоточная реализация.
+//! - `concurrent`: потокобезопасная обёртка с `Arc<RwLock>`
+//! - `sharded`: сегментированная поставка для высокого параллелизма.
+//! - `безопасность`: валидация и статистика
+
 pub mod safety;
-pub mod sharded;
 pub mod skiplist_base;
+
+#[cfg(feature = "concurrent")]
+pub mod concurrent;
+#[cfg(feature = "concurrent")]
+pub mod sharded;
 
 // Publicly re-export all error types and functions from the submodules to
 // simplify access from external code.
+#[cfg(feature = "concurrent")]
 pub use concurrent::*;
 pub use safety::*;
+#[cfg(feature = "concurrent")]
 pub use sharded::*;
 pub use skiplist_base::*;

--- a/src/database/skiplist/sharded.rs
+++ b/src/database/skiplist/sharded.rs
@@ -50,6 +50,7 @@ where
         let shards: Vec<_> = (0..num_shards)
             .map(|_| Arc::new(RwLock::new(SkipList::new())))
             .collect();
+
         let shard_metrics: Vec<_> = (0..num_shards)
             .map(|_| Arc::new(ShardMetrics::default()))
             .collect();

--- a/src/database/skiplist/skiplist_base.rs
+++ b/src/database/skiplist/skiplist_base.rs
@@ -27,10 +27,8 @@ pub struct Node<K, V> {
 pub struct SkipList<K, V> {
     /// Головной (dummy) узел; не содержит полезных данных.
     head: Box<Node<K, V>>,
-
     /// Текущий максимальный уровень.
     level: usize,
-
     /// Количество элементов (без головы).
     length: usize,
 }

--- a/src/database/smarthash/smarthash_base.rs
+++ b/src/database/smarthash/smarthash_base.rs
@@ -348,8 +348,8 @@ mod tests {
         sh.extend(pairs.clone());
         let mut got: Vec<_> = sh.iter().collect();
         let mut expected: Vec<_> = pairs.iter().map(|(k, v)| (k, v)).collect();
-        got.sort_by(|(a, _), (b, _)| a.cmp(b));
-        expected.sort_by(|(a, _), (b, _)| a.cmp(b));
+        got.sort_by_key(|(a, _)| *a);
+        expected.sort_by_key(|(a, _)| *a);
         assert_eq!(got, expected);
     }
 
@@ -390,7 +390,7 @@ mod tests {
         sh.extend(pairs.clone());
         let mut got: Vec<_> = sh.iter().collect();
         // Сортировать по ключу для стабильности
-        got.sort_by(|(a, _), (b, _)| a.cmp(b));
+        got.sort_by_key(|(a, _)| *a);
         let mut expected = pairs.clone();
         expected.sort_by(|(a, _), (b, _)| a.cmp(b));
         let expected_refs: Vec<_> = expected.iter().map(|(k, v)| (k, v)).collect();

--- a/src/engine/slot_manager.rs
+++ b/src/engine/slot_manager.rs
@@ -418,8 +418,8 @@ impl SlotManager {
                     }
                 }
 
-                overloaded_shards.sort_by(|a, b| b.1.cmp(&a.1));
-                underloaded_shards.sort_by(|a, b| a.1.cmp(&b.1));
+                overloaded_shards.sort_by_key(|b| std::cmp::Reverse(b.1));
+                underloaded_shards.sort_by_key(|a| a.1);
 
                 let assignments = self.slot_assignments.read().unwrap();
 
@@ -498,8 +498,8 @@ impl SlotManager {
             return migrations;
         }
 
-        overloaded.sort_by(|a, b| b.1.cmp(&a.1));
-        underloaded.sort_by(|a, b| a.1.cmp(&b.1));
+        overloaded.sort_by_key(|b| std::cmp::Reverse(b.1));
+        underloaded.sort_by_key(|a| a.1);
 
         let assignments = self.slot_assignments.read().unwrap();
 
@@ -657,7 +657,7 @@ impl SlotManager {
             .map(|(k, &c)| (k.clone(), c))
             .collect();
 
-        hot_keys.sort_by(|a, b| b.1.cmp(&a.1));
+        hot_keys.sort_by_key(|b| std::cmp::Reverse(b.1));
         hot_keys
     }
 


### PR DESCRIPTION
Replace std::sync::RwLock with parking_lot::RwLock for ConcurrentSkipList

- Replaced all std::sync::RwLock and RwLockReadGuard with parking_lot equivalents
- Updated try_insert / try_search to use parking_lot::RwLock's try_*_for() with timeout
- Removed polling loops and std::thread::yield_now()
- Kept cached_length and contention metrics unchanged
- No semantic changes, just improved concurrency performance and efficiency

# Pull Request

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated
  - [x] Added the necessary rustdoc comments.
  - [x] Changelog updated if applicable
