### PR TITLE
feat(skiplist): add ShardMetricsSnapshot and metrics snapshot API

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [[bench]]
 name = "zumic-benchmark"
-path = "benches/skiplist_benchmark/skiplist_bench.rs"
+path = "benches/skiplist_benchmark/concurrent_bench.rs"
 harness = false
 
 [lints]

--- a/benches/benches/skiplist_benchmark/concurrent_bench.rs
+++ b/benches/benches/skiplist_benchmark/concurrent_bench.rs
@@ -1,0 +1,462 @@
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc, Barrier,
+    },
+    thread,
+    time::Duration,
+};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use zumic::{database::ShardedSkipList, ConcurrentSkipList};
+
+/// Создаёт набор random ключей для тестирования.
+fn make_keys(
+    n: usize,
+    seed: u64,
+) -> Vec<i64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n).map(|_| rng.gen()).collect()
+}
+
+/// Benchmark: Concurrent inserts с разным количеством threads.
+fn bench_concurrent_inserts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_inserts");
+
+    for &num_threads in &[1, 2, 4, 8, 16] {
+        for &ops_per_thread in &[1000, 10_000] {
+            let total_ops = num_threads * ops_per_thread;
+            group.throughput(Throughput::Elements(total_ops as u64));
+
+            // ConcurrentSkipList (global lock)
+            group.bench_with_input(
+                BenchmarkId::new(
+                    "concurrent",
+                    format!("{}t_{}ops", num_threads, ops_per_thread),
+                ),
+                &(num_threads, ops_per_thread),
+                |b, &(num_threads, ops_per_thread)| {
+                    b.iter(|| {
+                        let list = ConcurrentSkipList::new();
+                        let barrier = Arc::new(Barrier::new(num_threads));
+                        let mut handles = vec![];
+
+                        for tid in 0..num_threads {
+                            let list = list.clone();
+                            let barrier = Arc::clone(&barrier);
+                            let keys = make_keys(ops_per_thread, (tid as u64) * 42);
+
+                            handles.push(thread::spawn(move || {
+                                barrier.wait();
+                                for key in keys {
+                                    list.insert(key, key);
+                                }
+                            }));
+                        }
+
+                        for h in handles {
+                            h.join().unwrap();
+                        }
+                    })
+                },
+            );
+
+            // ShardedSkipList
+            group.bench_with_input(
+                BenchmarkId::new("sharded", format!("{}t_{}ops", num_threads, ops_per_thread)),
+                &(num_threads, ops_per_thread),
+                |b, &(num_threads, ops_per_thread)| {
+                    b.iter(|| {
+                        let list = ShardedSkipList::with_shards(num_threads.max(16));
+                        let barrier = Arc::new(Barrier::new(num_threads));
+                        let mut handles = vec![];
+
+                        for tid in 0..num_threads {
+                            let list = list.clone();
+                            let barrier = Arc::clone(&barrier);
+                            let keys = make_keys(ops_per_thread, (tid as u64) * 42);
+
+                            handles.push(thread::spawn(move || {
+                                barrier.wait();
+                                for key in keys {
+                                    list.insert(key, key);
+                                }
+                            }));
+                        }
+
+                        for h in handles {
+                            h.join().unwrap();
+                        }
+                    })
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+/// Benchmark: Concurrent reads (100% read workload).
+fn bench_concurrent_reads(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_reads");
+
+    for &num_threads in &[1, 2, 4, 8, 16] {
+        let ops_per_thread = 10_000;
+        let total_ops = num_threads * ops_per_thread;
+        group.throughput(Throughput::Elements(total_ops as u64));
+
+        // Подготовка: заполняем список
+        let list = ConcurrentSkipList::new();
+        let keys = make_keys(10_000, 123);
+        for key in &keys {
+            list.insert(*key, *key);
+        }
+
+        group.bench_with_input(
+            BenchmarkId::new("concurrent", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                b.iter(|| {
+                    let barrier = Arc::new(Barrier::new(num_threads));
+                    let mut handles = vec![];
+
+                    for _ in 0..num_threads {
+                        let list = list.clone();
+                        let barrier = Arc::clone(&barrier);
+                        let keys = keys.clone();
+
+                        handles.push(thread::spawn(move || {
+                            barrier.wait();
+                            for key in keys {
+                                std::hint::black_box(list.search(&key));
+                            }
+                        }));
+                    }
+
+                    for h in handles {
+                        h.join().unwrap();
+                    }
+                })
+            },
+        );
+
+        // ShardedSkipList reads
+        let sharded_list = ShardedSkipList::with_shards(num_threads.max(16));
+        for key in &keys {
+            sharded_list.insert(*key, *key);
+        }
+
+        group.bench_with_input(
+            BenchmarkId::new("sharded", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                b.iter(|| {
+                    let barrier = Arc::new(Barrier::new(num_threads));
+                    let mut handles = vec![];
+
+                    for _ in 0..num_threads {
+                        let list = sharded_list.clone();
+                        let barrier = Arc::clone(&barrier);
+                        let keys = keys.clone();
+
+                        handles.push(thread::spawn(move || {
+                            barrier.wait();
+                            for key in keys {
+                                std::hint::black_box(list.search(&key));
+                            }
+                        }));
+                    }
+
+                    for h in handles {
+                        h.join().unwrap();
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark: Mixed workload (read/write ratios).
+fn bench_mixed_workload(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mixed_workload");
+
+    let num_threads = 8;
+    let duration = Duration::from_millis(500);
+
+    for &read_percentage in &[50, 80, 95, 99] {
+        group.bench_with_input(
+            BenchmarkId::new("concurrent", format!("{}%reads", read_percentage)),
+            &read_percentage,
+            |b, &read_pct| {
+                b.iter(|| {
+                    let list = ConcurrentSkipList::new();
+
+                    // Предварительно заполняем
+                    for i in 0..1000 {
+                        list.insert(i, i);
+                    }
+
+                    let stop = Arc::new(AtomicBool::new(false));
+                    let total_ops = Arc::new(AtomicUsize::new(0));
+                    let mut handles = vec![];
+
+                    for _ in 0..num_threads {
+                        let list = list.clone();
+                        let stop = Arc::clone(&stop);
+                        let ops = Arc::clone(&total_ops);
+
+                        handles.push(thread::spawn(move || {
+                            let mut rng = rand::thread_rng();
+                            while !stop.load(Ordering::Relaxed) {
+                                let key = rng.gen_range(0..1000);
+
+                                if rng.gen_range(0..100) < read_pct {
+                                    // Read
+                                    std::hint::black_box(list.search(&key));
+                                } else {
+                                    // Write
+                                    list.insert(key, key);
+                                }
+
+                                ops.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }));
+                    }
+
+                    thread::sleep(duration);
+                    stop.store(true, Ordering::Relaxed);
+
+                    for h in handles {
+                        h.join().unwrap();
+                    }
+
+                    total_ops.load(Ordering::Relaxed)
+                })
+            },
+        );
+
+        // ShardedSkipList
+        group.bench_with_input(
+            BenchmarkId::new("sharded", format!("{}%reads", read_percentage)),
+            &read_percentage,
+            |b, &read_pct| {
+                b.iter(|| {
+                    let list = ShardedSkipList::with_shards(16);
+
+                    for i in 0..1000 {
+                        list.insert(i, i);
+                    }
+
+                    let stop = Arc::new(AtomicBool::new(false));
+                    let total_ops = Arc::new(AtomicUsize::new(0));
+                    let mut handles = vec![];
+
+                    for _ in 0..num_threads {
+                        let list = list.clone();
+                        let stop = Arc::clone(&stop);
+                        let ops = Arc::clone(&total_ops);
+
+                        handles.push(thread::spawn(move || {
+                            let mut rng = rand::thread_rng();
+                            while !stop.load(Ordering::Relaxed) {
+                                let key = rng.gen_range(0..1000);
+
+                                if rng.gen_range(0..100) < read_pct {
+                                    std::hint::black_box(list.search(&key));
+                                } else {
+                                    list.insert(key, key);
+                                }
+
+                                ops.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }));
+                    }
+
+                    thread::sleep(duration);
+                    stop.store(true, Ordering::Relaxed);
+
+                    for h in handles {
+                        h.join().unwrap();
+                    }
+
+                    total_ops.load(Ordering::Relaxed)
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark: Scalability (fixed work, varying threads).
+fn bench_scalability(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scalability");
+
+    let total_ops = 100_000;
+
+    for &num_threads in &[1, 2, 4, 8, 16, 32] {
+        let ops_per_thread = total_ops / num_threads;
+
+        // ConcurrentSkipList
+        group.bench_with_input(
+            BenchmarkId::new("concurrent", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                b.iter(|| {
+                    let list = ConcurrentSkipList::new();
+                    let barrier = Arc::new(Barrier::new(num_threads));
+                    let mut handles = vec![];
+
+                    for tid in 0..num_threads {
+                        let list = list.clone();
+                        let barrier = Arc::clone(&barrier);
+                        let keys = make_keys(ops_per_thread, (tid as u64) * 123);
+
+                        handles.push(thread::spawn(move || {
+                            barrier.wait();
+                            for key in keys {
+                                list.insert(key, key);
+                            }
+                        }));
+                    }
+
+                    for h in handles {
+                        h.join().unwrap();
+                    }
+                })
+            },
+        );
+
+        // ShardedSkipList
+        group.bench_with_input(
+            BenchmarkId::new("sharded", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                b.iter(|| {
+                    let list = ShardedSkipList::with_shards(num_threads.max(16));
+                    let barrier = Arc::new(Barrier::new(num_threads));
+                    let mut handles = vec![];
+
+                    for tid in 0..num_threads {
+                        let list = list.clone();
+                        let barrier = Arc::clone(&barrier);
+                        let keys = make_keys(ops_per_thread, (tid as u64) * 123);
+
+                        handles.push(thread::spawn(move || {
+                            barrier.wait();
+                            for key in keys {
+                                list.insert(key, key);
+                            }
+                        }));
+                    }
+
+                    for h in handles {
+                        h.join().unwrap();
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark: Lock contention под высокой нагрузкой.
+fn bench_contention(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lock_contention");
+
+    let num_threads = 16;
+    let duration = Duration::from_millis(200);
+
+    // Hot keys (все threads работают с одними ключами)
+    group.bench_function("hot_keys_concurrent", |b| {
+        b.iter(|| {
+            let list = ConcurrentSkipList::new();
+
+            // 10 hot keys
+            for i in 0..10 {
+                list.insert(i, i);
+            }
+
+            let stop = Arc::new(AtomicBool::new(false));
+            let mut handles = vec![];
+
+            for _ in 0..num_threads {
+                let list = list.clone();
+                let stop = Arc::clone(&stop);
+
+                handles.push(thread::spawn(move || {
+                    let mut rng = rand::thread_rng();
+                    let mut count = 0;
+
+                    while !stop.load(Ordering::Relaxed) {
+                        let key = rng.gen_range(0..10);
+                        list.insert(key, key);
+                        count += 1;
+                    }
+
+                    count
+                }));
+            }
+
+            thread::sleep(duration);
+            stop.store(true, Ordering::Relaxed);
+
+            let total: usize = handles.into_iter().map(|h| h.join().unwrap()).sum();
+            total
+        })
+    });
+
+    group.bench_function("hot_keys_sharded", |b| {
+        b.iter(|| {
+            let list = ShardedSkipList::with_shards(16);
+
+            for i in 0..10 {
+                list.insert(i, i);
+            }
+
+            let stop = Arc::new(AtomicBool::new(false));
+            let mut handles = vec![];
+
+            for _ in 0..num_threads {
+                let list = list.clone();
+                let stop = Arc::clone(&stop);
+
+                handles.push(thread::spawn(move || {
+                    let mut rng = rand::thread_rng();
+                    let mut count = 0;
+
+                    while !stop.load(Ordering::Relaxed) {
+                        let key = rng.gen_range(0..10);
+                        list.insert(key, key);
+                        count += 1;
+                    }
+
+                    count
+                }));
+            }
+
+            thread::sleep(duration);
+            stop.store(true, Ordering::Relaxed);
+
+            let total: usize = handles.into_iter().map(|h| h.join().unwrap()).sum();
+            total
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_concurrent_inserts,
+    bench_concurrent_reads,
+    bench_mixed_workload,
+    bench_scalability,
+    bench_contention
+);
+
+criterion_main!(benches);

--- a/src/command/execute.rs
+++ b/src/command/execute.rs
@@ -27,7 +27,8 @@ use crate::{
     command::{
         pubsub::{PubSubCommand, PublishCommand, SubscribeCommand, UnsubscribeCommand},
         BgSaveCommand, DbSizeCommand, EchoCommand, InfoCommand, PingCommand, SaveCommand,
-        SelectCommand, ShutdownCommand, TimeCommand,
+        SelectCommand, ShutdownCommand, TimeCommand, TsAddCommand, TsCreateCommand, TsDelCommand,
+        TsGetCommand, TsRangeCommand,
     },
     logging::slow_log::SlowQueryTracker,
     StorageEngine, StoreError, Value,
@@ -177,6 +178,11 @@ pub enum Command {
     XTrim(XTrimCommand),
     XGroupCreate(XGroupCreateCommand),
     XAck(XAckCommand),
+    TsCreate(TsCreateCommand),
+    TsAdd(TsAddCommand),
+    TsGet(TsGetCommand),
+    TsRange(TsRangeCommand),
+    TsDel(TsDelCommand),
 }
 
 impl Command {
@@ -281,6 +287,11 @@ impl Command {
             Command::XTrim(_) => "XTRIM",
             Command::XGroupCreate(_) => "XGROUP CREATE",
             Command::XAck(_) => "XACK",
+            Command::TsCreate(_) => "TS.CREATE",
+            Command::TsAdd(_) => "TS.ADD",
+            Command::TsGet(_) => "TS.GET",
+            Command::TsRange(_) => "TS.RANGE",
+            Command::TsDel(_) => "TS.DEL",
         }
     }
 
@@ -385,6 +396,11 @@ impl Command {
             Command::XTrim(cmd) => Some(cmd.key.as_bytes()),
             Command::XGroupCreate(cmd) => Some(cmd.key.as_bytes()),
             Command::XAck(cmd) => Some(cmd.key.as_bytes()),
+            Command::TsCreate(cmd) => Some(cmd.key.as_bytes()),
+            Command::TsAdd(cmd) => Some(cmd.key.as_bytes()),
+            Command::TsGet(cmd) => Some(cmd.key.as_bytes()),
+            Command::TsRange(cmd) => Some(cmd.key.as_bytes()),
+            Command::TsDel(cmd) => Some(cmd.key.as_bytes()),
         }
     }
 }
@@ -505,6 +521,11 @@ impl CommandExecute for Command {
             Command::XTrim(cmd) => cmd.execute(store),
             Command::XGroupCreate(cmd) => cmd.execute(store),
             Command::XAck(cmd) => cmd.execute(store),
+            Command::TsCreate(cmd) => cmd.execute(store),
+            Command::TsAdd(cmd) => cmd.execute(store),
+            Command::TsGet(cmd) => cmd.execute(store),
+            Command::TsRange(cmd) => cmd.execute(store),
+            Command::TsDel(cmd) => cmd.execute(store),
         };
 
         // Добавляем result / error в tracker (используем ссылку, чтобы не перемещать

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -35,6 +35,7 @@ pub mod server;
 pub mod set;
 pub mod stream;
 pub mod string;
+pub mod timeseries;
 pub mod zset;
 
 // Publicly re-export all error types and functions from the submodules to
@@ -53,4 +54,5 @@ pub use server::*;
 pub use set::*;
 pub use stream::*;
 pub use string::*;
+pub use timeseries::*;
 pub use zset::*;

--- a/src/command/timeseries.rs
+++ b/src/command/timeseries.rs
@@ -1,0 +1,100 @@
+use crate::CommandExecute;
+
+#[derive(Debug)]
+pub struct TsCreateCommand {
+    pub key: String,
+    pub retention_ms: Option<u64>,
+    pub labels: Vec<(String, String)>,
+}
+
+impl CommandExecute for TsCreateCommand {
+    fn execute(
+        &self,
+        _store: &mut crate::StorageEngine,
+    ) -> Result<crate::Value, crate::StoreError> {
+        unimplemented!("TS.CREATE is not implemented yet")
+    }
+
+    fn command_name(&self) -> &'static str {
+        "TS.CREATE"
+    }
+}
+
+#[derive(Debug)]
+pub struct TsAddCommand {
+    pub key: String,
+    pub timestamp: u64,
+    pub value: f64,
+}
+
+impl CommandExecute for TsAddCommand {
+    fn execute(
+        &self,
+        _store: &mut crate::StorageEngine,
+    ) -> Result<crate::Value, crate::StoreError> {
+        unimplemented!("TS.ADD is not implemented yet")
+    }
+
+    fn command_name(&self) -> &'static str {
+        "TS.ADD"
+    }
+}
+
+#[derive(Debug)]
+pub struct TsGetCommand {
+    pub key: String,
+}
+
+impl CommandExecute for TsGetCommand {
+    fn execute(
+        &self,
+        _store: &mut crate::StorageEngine,
+    ) -> Result<crate::Value, crate::StoreError> {
+        unimplemented!("TS.GET is not implemented yet")
+    }
+
+    fn command_name(&self) -> &'static str {
+        "TS.GET"
+    }
+}
+
+#[derive(Debug)]
+pub struct TsRangeCommand {
+    pub key: String,
+    pub from: u64,
+    pub to: u64,
+    pub count: Option<usize>,
+}
+
+impl CommandExecute for TsRangeCommand {
+    fn execute(
+        &self,
+        _store: &mut crate::StorageEngine,
+    ) -> Result<crate::Value, crate::StoreError> {
+        unimplemented!("TS.RANGE is not implemented yet")
+    }
+
+    fn command_name(&self) -> &'static str {
+        "TS.RANGE"
+    }
+}
+
+#[derive(Debug)]
+pub struct TsDelCommand {
+    pub key: String,
+    pub from: u64,
+    pub to: u64,
+}
+
+impl CommandExecute for TsDelCommand {
+    fn execute(
+        &self,
+        _store: &mut crate::StorageEngine,
+    ) -> Result<crate::Value, crate::StoreError> {
+        unimplemented!("TS.DEL is not implemented yet")
+    }
+
+    fn command_name(&self) -> &'static str {
+        "TS.DEL"
+    }
+}

--- a/src/database/types.rs
+++ b/src/database/types.rs
@@ -111,7 +111,3 @@ impl Value {
         }
     }
 }
-
-// NOTE: ВРЕМЕННАЯ ЗАГЛУШКА. ПОСЛЕ РЕАЛИЗАЦИИ SEND + SYNC В SKIPLIST
-unsafe impl Send for Value {}
-unsafe impl Sync for Value {}


### PR DESCRIPTION
- added ShardMetricsSnapshot struct for immutable shard metrics snapshots
- added helper methods: total_operations, average_wait_time_ns, format_report
- added ShardedSkipList::shard_metrics() for safe metrics collection
- improves observability and performance analysis without locking

# Pull Request

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated
  - [x] Added the necessary rustdoc comments.
  - [x] Changelog updated if applicable
