### PR TITLE
feat(dict): integrate ahash and make Dict generic over BuildHasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.2",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,7 +1311,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -4359,6 +4372,7 @@ dependencies = [
 name = "zumic"
 version = "0.5.0"
 dependencies = [
+ "ahash 0.8.12",
  "anyhow",
  "arbitrary",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ zstd = "0.13.3"
 zumic-error = { workspace = true }
 murmur3 = "0.5.2"
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
+ahash = "0.8.12"
 
 [dependencies.wasmtime]
 version = "36.0.3"


### PR DESCRIPTION
## Scope
database/dict

## Summary

- integrate `ahash` and make `Dict` generic over `BuildHasher`
- add constructors:
  - `Dict::with_hasher(hasher: S)`
  - `Dict::with_capacity_and_hasher(capacity: usize, hasher: S)`
- update all hash computation paths to use the configured hasher
- remove `unsafe` from `get_mut` by using safe mutable traversal
- update internal APIs and call sites to support generic hashers
- update tests to ensure compatibility with the new hashing abstraction

## Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] New tests added / existing tests updated
- [x] Added the necessary rustdoc comments
- [x] Changelog updated if applicable