### PR TITLE
feat(dict): added benchmark tests for the Entry API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@
 ### Добавлено
 
 - **database/dict**
+  - Добавлены benchmark-тесты для Entry API (`benches/benches/dict_benchmark/dict_entry_bench.rs`):
+    - `or_insert_hit` – измерение производительности доступа к существующим ключам.
+    - `or_insert_miss` – измерение производительности вставки новых ключей.
+    - `counter_pattern` – сравнение подходов `and_modify().or_insert()` и `get_mut().or_insert()` с повторяющимися ключами.
+    - `counter_pattern_collisions` – тест с искусственными коллизиями.
+    - `remove_via_entry` – измерение производительности удаления через `Entry::Occupied` и напрямую через `Dict::remove`.
+    - `or_default` – сравнение `or_default()` и `or_insert(Default::default())`.
+    - `mixed_hit_miss` – нагрузочный тест с 70% существующих и 30% новых ключей.
+    - Тесты используют Criterion и измеряют throughput, warm-up и sample_size для репрезентативных результатов.
+    - Сравнение с `std::collections::HashMap` для базовой метрики.
+
+- **database/dict**
+  - Добавлены интеграционные тесты Entry API (`tests/dict_entry_tests.rs`):
+    - Проверена корректность `or_insert`, включая вставку нового значения и сохранение существующего.
+    - Подтверждено, что `or_insert_with` вызывается только для vacant entry и ровно один раз.
+    - Проверена корректная работа `or_insert_with_key`, включая вычисление значения на основе ключа.
+    - Проверена корректность `or_default` для vacant и occupied entry.
+    - Проверена корректная работа `and_modify`, включая chained pattern (`and_modify().or_insert()`).
+    - Проверены все методы `OccupiedEntry`:
+      - `key`, `get`, `get_mut`, `into_mut`
+      - `insert` с возвратом старого значения
+      - `remove`, включая удаление:
+        - головы цепочки
+        - элемента внутри цепочки
+    - Проверены методы `VacantEntry`:
+      - `key`
+      - `into_key`
+      - `insert` с последующей мутацией значения
+    - Проверена корректность работы Entry API во время активного rehash.
+    - Подтверждено отсутствие дубликатов ключей при повторных вызовах Entry API.
+    - Проверена корректность удаления и повторной вставки через Entry API.
+    - Добавлены large-scale тесты корректности (тысячи ключей).
+    - Подтверждены гарантии:
+      - корректность ссылок и lifetimes
+      - отсутствие двойного поиска
+      - корректность работы во всех состояниях таблицы (rehash, collision chains, mutation).
+
+- **database/dict**
   - Добавлены comprehensive unit-тесты для Entry API (`tests/dict/entry.rs`):
     - Проверка `or_insert` для vacant и occupied случаев.
     - Проверка, что `or_insert_with` вызывается ровно один раз.

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [[bench]]
 name = "zumic-benchmark"
-path = "benches/dict_benchmark/dict_rehash_bench.rs"
+path = "benches/dict_benchmark/dict_entry_bench.rs"
 harness = false
 
 [lints]

--- a/benches/benches/dict_benchmark/dict_entry_bench.rs
+++ b/benches/benches/dict_benchmark/dict_entry_bench.rs
@@ -1,0 +1,318 @@
+use std::{collections::HashMap, hint::black_box, time::Duration};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use zumic::Dict;
+
+const SIZES: &[usize] = &[100, 1_000, 10_000, 100_000];
+
+fn bench_or_insert_hit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("entry/or_insert_hit");
+    group.warm_up_time(Duration::from_secs(2));
+    group.measurement_time(Duration::from_secs(5));
+    group.sample_size(100);
+
+    for &n in SIZES {
+        group.throughput(Throughput::Elements(n as u64));
+
+        let mut base: Dict<u64, u64> = Dict::new();
+        for i in 0..n as u64 {
+            base.insert(i, i);
+        }
+
+        group.bench_with_input(BenchmarkId::new("entry_or_insert", n), &n, |b, &_n| {
+            b.iter_batched(
+                || base.clone(),
+                |mut d| {
+                    for i in 0..n as u64 {
+                        let v = d.entry(black_box(i)).or_insert(0);
+                        black_box(v);
+                    }
+                    black_box(d)
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        // Zumic Dict get_then_insert
+        group.bench_with_input(BenchmarkId::new("get_then_insert", n), &n, |b, &_n| {
+            b.iter_batched(
+                || base.clone(),
+                |mut d| {
+                    for i in 0..n as u64 {
+                        if let Some(v) = d.get(black_box(&i)) {
+                            black_box(v);
+                        } else {
+                            d.insert(i, 0);
+                        }
+                    }
+                    black_box(d)
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        let mut base_std: HashMap<u64, u64> = HashMap::new();
+        for i in 0..n as u64 {
+            base_std.insert(i, i);
+        }
+
+        group.bench_with_input(
+            BenchmarkId::new("std_hashmap_entry_or_insert", n),
+            &n,
+            |b, &_n| {
+                b.iter_batched(
+                    || base_std.clone(),
+                    |mut m| {
+                        for i in 0..n as u64 {
+                            let v = m.entry(black_box(i)).or_insert(0);
+                            black_box(v);
+                        }
+                        black_box(m)
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_or_insert_miss(c: &mut Criterion) {
+    let mut group = c.benchmark_group("entry/or_insert_miss");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+    group.sample_size(60);
+
+    for &n in SIZES {
+        group.throughput(Throughput::Elements(n as u64));
+
+        let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+        let keys: Vec<u64> = (0..n).map(|_| rng.gen::<u64>()).collect();
+
+        group.bench_with_input(BenchmarkId::new("entry_or_insert", n), &n, |b, &_n| {
+            b.iter_batched(
+                || Dict::<u64, u64>::new(),
+                |mut d| {
+                    for &k in &keys {
+                        d.entry(black_box(k))
+                            .or_insert(black_box(k.wrapping_mul(2)));
+                    }
+                    black_box(d)
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_with_input(BenchmarkId::new("get_then_insert", n), &n, |b, &_n| {
+            b.iter_batched(
+                || Dict::<u64, u64>::new(),
+                |mut d| {
+                    for &k in &keys {
+                        if d.get(black_box(&k)).is_none() {
+                            d.insert(k, black_box(k.wrapping_mul(2)));
+                        }
+                    }
+                    black_box(d)
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_counter_pattern(c: &mut Criterion) {
+    let mut group = c.benchmark_group("entry/counter_pattern");
+    const N: usize = 1_000;
+
+    let keys: Vec<u64> = (0..N as u64 * 5).map(|i| i % (N as u64 / 2)).collect();
+
+    group.throughput(Throughput::Elements(keys.len() as u64));
+
+    group.bench_function("entry_and_modify_or_insert", |b| {
+        b.iter_batched(
+            || Dict::<u64, u64>::new(),
+            |mut d| {
+                for &k in &keys {
+                    d.entry(black_box(k)).and_modify(|v| *v += 1).or_insert(1);
+                }
+                black_box(d)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("get_mut_or_insert", |b| {
+        b.iter_batched(
+            || Dict::<u64, u64>::new(),
+            |mut d| {
+                for &k in &keys {
+                    if let Some(v) = d.get_mut(black_box(&k)) {
+                        *v += 1;
+                    } else {
+                        d.insert(k, 1);
+                    }
+                }
+                black_box(d)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    let keys_collide: Vec<u64> = (0u64..(N as u64 * 5)).map(|i| i % 16).collect();
+    group.bench_function("counter_pattern_collisions", |b| {
+        b.iter_batched(
+            || Dict::<u64, u64>::new(),
+            |mut d| {
+                for &k in &keys_collide {
+                    d.entry(black_box(k)).and_modify(|v| *v += 1).or_insert(1);
+                }
+                black_box(d)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_remove_via_entry(c: &mut Criterion) {
+    use zumic::database::dict::entry::Entry;
+    let mut group = c.benchmark_group("entry/remove");
+    const N: usize = 1_000;
+    group.throughput(Throughput::Elements(N as u64));
+
+    group.bench_function("entry_remove", |b| {
+        b.iter_batched(
+            || {
+                let mut d = Dict::<u64, u64>::new();
+                for i in 0..N as u64 {
+                    d.insert(i, i);
+                }
+                d
+            },
+            |mut d| {
+                for i in 0..N as u64 {
+                    if let Entry::Occupied(e) = d.entry(black_box(i)) {
+                        black_box(e.remove());
+                    }
+                }
+                black_box(d)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("dict_remove", |b| {
+        b.iter_batched(
+            || {
+                let mut d = Dict::<u64, u64>::new();
+                for i in 0..N as u64 {
+                    d.insert(i, i);
+                }
+                d
+            },
+            |mut d| {
+                for i in 0..N as u64 {
+                    black_box(d.remove(black_box(&i)));
+                }
+                black_box(d)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_or_default(c: &mut Criterion) {
+    let mut group = c.benchmark_group("entry/or_default");
+    const N: usize = 1_000;
+    group.throughput(Throughput::Elements(N as u64));
+
+    group.bench_function("or_default", |b| {
+        b.iter_batched(
+            || Dict::<u64, u64>::new(),
+            |mut d| {
+                for i in 0..N as u64 {
+                    black_box(d.entry(black_box(i)).or_default());
+                }
+                black_box(d)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("or_insert_default", |b| {
+        b.iter_batched(
+            || Dict::<u64, u64>::new(),
+            |mut d| {
+                for i in 0..N as u64 {
+                    black_box(d.entry(black_box(i)).or_insert(u64::default()));
+                }
+                black_box(d)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_mixed_hit_miss(c: &mut Criterion) {
+    let mut group = c.benchmark_group("entry/mixed_70hit_30miss");
+    const N: usize = 1_000;
+    group.throughput(Throughput::Elements(N as u64));
+
+    let mut d_base = Dict::<u64, u64>::new();
+    for i in 0..700u64 {
+        d_base.insert(i, i);
+    }
+
+    group.bench_function("entry_or_insert", |b| {
+        b.iter_batched(
+            || d_base.clone(),
+            |mut d| {
+                for i in 0..N as u64 {
+                    let v = d.entry(black_box(i)).or_insert(black_box(i * 2));
+                    black_box(v);
+                }
+                black_box(d)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("get_then_insert", |b| {
+        b.iter_batched(
+            || d_base.clone(),
+            |mut d| {
+                for i in 0..N as u64 {
+                    if let Some(v) = d.get(black_box(&i)) {
+                        black_box(v);
+                    } else {
+                        d.insert(i, black_box(i * 2));
+                    }
+                }
+                black_box(d)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_or_insert_hit,
+    bench_or_insert_miss,
+    bench_counter_pattern,
+    bench_remove_via_entry,
+    bench_or_default,
+    bench_mixed_hit_miss,
+);
+criterion_main!(benches);


### PR DESCRIPTION
- Added benchmark tests for the Entry API (`benches/benches/dict_benchmark/dict_entry_bench.rs`):
  - `or_insert_hit` – measures performance for accessing existing keys.
  - `or_insert_miss` – measures performance for inserting new keys.
  - `counter_pattern` – compares `and_modify().or_insert()` vs `get_mut().or_insert()` for repeated keys.
  - `counter_pattern_collisions` – tests behavior under artificial key collisions.
  - `remove_via_entry` – measures removal via `Entry::Occupied` and directly via `Dict::remove`.
  - `or_default` – compares `or_default()` vs `or_insert(Default::default())`.
  - `mixed_hit_miss` – load test with 70% hits and 30% misses.
  - Tests use Criterion for benchmarking, with configured throughput, warm-up, and sample_size for representative results.
  - Includes comparison against `std::collections::HashMap` as a baseline.

# Pull Request

Please include:

- **Scope**: what area of the codebase this touches (e.g. `database`, `network`, `pubsub`).
- **Summary**: brief description of the change.
- **Testing**: how did you verify it works? (unit tests, manual steps).
- **Checklist**:
  - [x] `cargo fmt --check`
  - [x] `cargo clippy -- -D warnings`
  - [x] New tests added / existing tests updated
  - [x] Added the necessary rustdoc comments.
  - [x] Changelog updated if applicable
